### PR TITLE
Add backup feeds for RSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Optional settings can be configured an Docker run time, or be set in your local 
 
 ## Docker:
 
-docker run --rm -v rss-firehose:/usr/src/app/public -e "RSS_TITLE=My News" -e "RSS_URLS=https://url1/feed,http://url2/rss" -e "ANALYTICS_UA=UA-XXXXX-Y" -it djdefi/rss-firehose
+docker run --rm -v rss-firehose:/usr/src/app/public -e "RSS_TITLE=My News" -e "RSS_URLS=https://url1/feed,http://url2/rss" -e "RSS_BACKUP_URLS=https://backup1/feed,http://backup2/rss" -e "ANALYTICS_UA=UA-XXXXX-Y" -it djdefi/rss-firehose
 
 ## Ruby:
 
 export RSS_URLS="https://url1/feed,http://url2/rss"
+export RSS_BACKUP_URLS="https://backup1/feed,http://backup2/rss"
 ruby render.rb
 
 ```
@@ -60,6 +61,7 @@ Available environment variable options:
 ```
 "ANALYTICS_UA=UA-XXXXX-Y"
 "RSS_URLS=https://url1/feed,http://url2/rss"
+"RSS_BACKUP_URLS=https://backup1/feed,http://backup2/rss"
 "RSS_TITLE=My News"
 "RSS_DESCRIPTION=My really awesome news aggregation page"
 ```

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -23,5 +23,16 @@ class RenderTest < Minitest::Test
     assert_includes output, placeholder_message, "The placeholder message for a parsing error is not correctly inserted."
   end
 
+  def test_backup_feed_functionality
+    # Simulate a primary feed failure and verify backup feed is used
+    primary_feed_url = "http://example.com/primary_feed"
+    backup_feed_url = "http://example.com/backup_feed"
+    placeholder_message = "<a href='http://example.com/backup_feed'>http://example.com/backup_feed - 0 items:</a>"
+    # Run render.rb with the primary feed URL and backup feed URL
+    `RSS_URLS=#{primary_feed_url} RSS_BACKUP_URLS=#{backup_feed_url} ruby render.rb`
+    output = File.read('public/index.html')
+    assert_includes output, placeholder_message, "The backup feed is not correctly used when the primary feed fails."
+  end
+
   # Additional tests to verify specific content or structure can be added here
 end


### PR DESCRIPTION
Add backup feeds to be used if primary feeds are down or unresponsive.

* Modify `rss_urls` method in `render.rb` to include backup feeds from `rss_backup_urls` method.
* Add `rss_backup_urls` method in `render.rb` to fetch backup feeds from `RSS_BACKUP_URLS` environment variable, with default backup feed `https://calmatters.org/feed/`.
* Update `feed` method in `render.rb` to switch to backup feeds if primary feeds fail after retry.
* Update `README.md` to include instructions for setting up backup feeds using `RSS_BACKUP_URLS` environment variable.
* Add tests in `test/render_test.rb` to verify the functionality of backup feeds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/djdefi/rss-firehose/pull/167?shareId=0e8421aa-6173-4a70-8912-4504830d9c96).