### PR TITLE
Escape feed content & normalize Atom/RSS2 items (XSS fix)

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -140,6 +140,31 @@ def html_escape(text)
       .gsub("'", '&#39;')
 end
 
+# Normalize an item title across feed dialects: RSS2 exposes a String, Atom an
+# object with #content. Always returns a String so callers can safely escape it.
+def item_title(item)
+  raw = item.title
+  raw.respond_to?(:content) ? raw.content.to_s : raw.to_s
+end
+
+# Normalize an item link across feed dialects: RSS2 exposes a String, Atom an
+# object with #href. Always returns a String.
+def item_link(item)
+  raw = item.link
+  return raw.href.to_s if raw.respond_to?(:href)
+  return raw.content.to_s if raw.respond_to?(:content)
+
+  raw.to_s
+end
+
+# Allow only safe URL schemes in generated hrefs so a malicious feed can't inject
+# javascript:/data:/vbscript: links. Absolute, protocol-relative, root-relative
+# and anchor links pass through; anything else collapses to '#'.
+def safe_url(url)
+  str = url.to_s.strip
+  str.match?(%r{\A(?:https?://|ftp://|mailto:|//|/|\#)}i) ? str : '#'
+end
+
 def sanitize_response(response_body)
   JSON.parse(response_body)
 rescue JSON::ParserError => e
@@ -287,7 +312,7 @@ end
 def extract_feed_content(feed)
   return [] if feed.nil? || !feed.respond_to?(:items) || feed.items.nil?
   
-  feed.items.map { |item| "#{item.title} (#{item.link})" }.compact
+  feed.items.map { |item| "#{item_title(item)} (#{item_link(item)})" }.compact
 rescue => e
   puts "Error extracting feed content: #{e.message}"
   []

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -41,8 +41,8 @@
       <ul>
         <% breaking_news.first(10).each do |news_item| -%>
           <li>
-            <strong><%= news_item[:timestamp] %></strong>: 
-            <a href='<%= news_item[:link] %>' aria-label="Breaking News Item"><%= news_item[:content] %></a>
+            <strong><%= html_escape(news_item[:timestamp]) %></strong>: 
+            <a href='<%= html_escape(safe_url(news_item[:link])) %>' aria-label="Breaking News Item"><%= html_escape(news_item[:content]) %></a>
           </li>
         <% end -%>
       </ul>
@@ -66,7 +66,7 @@
         <ul>
           <% parsed.items.each do |item| -%>
             <li>
-              <a href='<%= item.link %>' aria-label="Feed Item"><%= item.title %></a>
+              <a href='<%= html_escape(safe_url(item_link(item))) %>' aria-label="Feed Item"><%= html_escape(item_title(item)) %></a>
             </li>
           <% end -%>
         </ul>

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -158,4 +158,74 @@ class RenderTest < Minitest::Test
     
     puts "✓ Manifest PWA settings are correctly configured for iOS"
   end
+
+  # --- Feed-dialect normalization + XSS escaping ---------------------------
+
+  def test_item_title_normalizes_rss_and_atom
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>c</title><link>http://x</link>
+      <description>d</description>
+      <item><title>Plain Title</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    assert_equal "Plain Title", item_title(rss.items.first)
+
+    atom_item = Struct.new(:title, :link).new(
+      Struct.new(:content).new("Atom Title"), nil
+    )
+    assert_equal "Atom Title", item_title(atom_item)
+  end
+
+  def test_item_link_normalizes_rss_and_atom
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>c</title><link>http://x</link>
+      <description>d</description>
+      <item><title>t</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    assert_equal "http://x/1", item_link(rss.items.first)
+
+    atom_item = Struct.new(:title, :link).new(
+      nil, Struct.new(:href).new("https://atom.test/1")
+    )
+    assert_equal "https://atom.test/1", item_link(atom_item)
+  end
+
+  def test_safe_url_allows_safe_and_blocks_dangerous_schemes
+    assert_equal "https://ok.test/a", safe_url("https://ok.test/a")
+    assert_equal "http://ok.test", safe_url("http://ok.test")
+    assert_equal "/relative", safe_url("/relative")
+    assert_equal "#anchor", safe_url("#anchor")
+    assert_equal "mailto:a@b.test", safe_url("mailto:a@b.test")
+    assert_equal "#", safe_url("javascript:alert(1)")
+    assert_equal "#", safe_url("data:text/html;base64,PHNjcmlwdD4=")
+    assert_equal "#", safe_url("vbscript:msgbox(1)")
+  end
+
+  def test_render_escapes_malicious_feed_content
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>Evil</title><link>http://evil.test</link>
+      <description>d</description>
+      <item><title>Danger &lt;script&gt;alert(1)&lt;/script&gt;</title><link>javascript:alert(1)</link></item>
+      <item><title>Safe &amp; Sound</title><link>https://ok.test/a?b=1&amp;c=2</link></item>
+      </channel></rss>
+    XML
+    feeds = { "http://evil.test/feed" => feed }
+    render_html(feeds, "Overall summary", {}, [], nil)
+    output = File.read('public/index.html')
+
+    refute_includes output, "<script>alert(1)</script>",
+      "Malicious script title must be escaped, not injected raw."
+    assert_includes output, "Danger &lt;script&gt;alert(1)&lt;/script&gt;",
+      "Escaped title should appear in output."
+    refute_includes output, "href='javascript:alert(1)'",
+      "javascript: URLs must be neutralized."
+    assert_includes output, "href='#'",
+      "Dangerous URL should collapse to '#'."
+    assert_includes output, "Safe &amp; Sound",
+      "Ampersand in title should be escaped."
+  end
 end


### PR DESCRIPTION
## Summary
Part of the July 2026 bug-hunt cycle. Fixes a real **XSS / HTML-injection** vector and an **Atom rendering** bug, with no new features and no new runtime deps.

`RSS::Parser` *un-escapes* entities on parse, so a malicious or malformed feed could inject raw markup/script through item **titles**, **links**, and **breaking-news** content that were interpolated straight into the page.

## Changes
- **`item_title` / `item_link` normalizers** — RSS2 exposes Strings, Atom exposes objects (`#content` / `#href`). Atom items previously rendered as inspected objects / broken links; now normalized to Strings.
- **`safe_url` allowlist** — permits `https?://`, `ftp://`, `mailto:`, protocol-relative, root-relative and anchors; collapses `javascript:` / `data:` / `vbscript:` / unknown schemes to `#`.
- **Escape everything in the template** — feed item + breaking-news title/link/content go through `html_escape` (and `safe_url` for hrefs). Ampersands become `&amp;` (htmlproofer-safe).
- **`extract_feed_content`** routed through the new normalizers.

## Tests
- Unit coverage for `item_title` / `item_link` (RSS2 String + Atom object cases) and `safe_url` (safe vs dangerous schemes).
- End-to-end test: a `<script>` title is escaped (not injected) and a `javascript:` link is neutralized to `#`.

## Validation (Docker `ruby:4-alpine`, Ruby 4.0.5)
- New tests: **4 runs, 22 assertions, 0 failures**.
- Full suite: **15 runs, 50 assertions, 0 failures, 0 errors, 3 skips** (breaking-news skips — live source empty today).
- Live e2e render of real feeds: correct links, zero raw `<script`, ampersand hrefs entity-encoded.