### PR TITLE
Fix AI summary cache so it actually refreshes between runs

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -31,15 +31,19 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Caches the AI summary
-    - name: Cache AI summary
+    # Restores the most recent AI summary cache. A per-run key with a shared
+    # restore prefix is used so the cache actually refreshes: exact-key restore
+    # misses (unique per run) and falls back to the newest `ai-summary-` entry,
+    # while the save step below always writes a new key. (A single static key is
+    # immutable once written and would freeze the cache forever.)
+    - name: Restore AI summary cache
       id: cache-ai-summary
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: cache
-        key: ai-summary
+        key: ai-summary-${{ github.run_id }}
         restore-keys: |
-          ai-summary
+          ai-summary-
 
     # Sets up Ruby environment
     - name: Setup Ruby
@@ -54,17 +58,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.API_TOKEN }}
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}
 
-    # Prunes old summaries from the cache
-    - name: Prune old summaries
-      run: |
-        find cache -type f -name '*.json' -mtime +1 -delete
-
-    # Uploads the AI summary to the cache
-    - name: Upload AI summary to cache
-      uses: actions/cache@v4
+    # Saves the AI summary cache under a fresh per-run key so it always updates.
+    # Old entries are evicted by GitHub's cache retention policy.
+    - name: Save AI summary cache
+      if: always()
+      uses: actions/cache/save@v4
       with:
         path: cache
-        key: ai-summary
+        key: ai-summary-${{ github.run_id }}
 
     # Runs a Git AV scan
     - name: Git AV Scan


### PR DESCRIPTION
## Summary
The deploy's AI-summary cache never refreshed. `page.yml` used `actions/cache@v4` with a **single static key `ai-summary`** for both the restore step and the "upload" step. GitHub cache keys are **immutable once written**, so after the very first save the entry could never be updated — every subsequent post-job save was silently skipped (and the duplicate step produced the "Failed to restore:" warnings seen in deploy logs).

Combined with `render.rb`'s 6h TTL (an embedded timestamp in `cache/ai_summary_cache.json`), the effect was: ~6h after the first-ever run the cached summary is permanently stale, so **every scheduled run regenerates the AI summary from scratch and can never persist it** — exactly the upstream API strain the cache was meant to avoid, and directly relevant to the "did we ever implement caching to reduce strain / improve responsiveness" question.

## Fix — standard rotating-cache pattern
- **`actions/cache/restore@v4`** with a per-run key `ai-summary-${{ github.run_id }}` and a shared `ai-summary-` **restore prefix**, so restore falls back to the newest previous entry.
- **`actions/cache/save@v4`** (`if: always()`) under that fresh per-run key, so the cache is written on **every** run. GitHub's retention policy (7 days / 10 GB LRU) evicts old keys.
- Dropped the now-useless **"Prune old summaries"** step — with a single, always-fresh cache file the `-mtime +1` prune was a no-op.

## Behavior after this change
- Run within 6h of the cached timestamp: `render.rb` reuses the summary (no AI call), cache re-saved under a fresh key.
- Run after 6h: `render.rb` regenerates, writes the new summary, and it is **persisted** for the next run.
- First run post-merge does one regeneration (the legacy `ai-summary` key isn't matched by the new `ai-summary-` prefix), then rotates normally.

## Validation
`page.yml` is exercised only by the live deploy (no PR test covers it), so the authoritative check is the **post-merge deploy run** — I'll confirm it restores/saves cleanly with no "Failed to restore:" warnings. YAML validated locally.
