### PR TITLE
Bump Actions to Node 24 runtimes (resolve Node 20 deprecation)

### DIFF
--- a/.github/workflows/bundle-up.yml
+++ b/.github/workflows/bundle-up.yml
@@ -7,7 +7,7 @@ jobs:
     name: Bundle Update
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1.190.0
         with:
           ruby-version: 3 # ruby version of a project

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -29,7 +29,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     # Restores the most recent AI summary cache. A per-run key with a shared
     # restore prefix is used so the cache actually refreshes: exact-key restore
@@ -38,7 +38,7 @@ jobs:
     # immutable once written and would freeze the cache forever.)
     - name: Restore AI summary cache
       id: cache-ai-summary
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: cache
         key: ai-summary-${{ github.run_id }}
@@ -62,7 +62,7 @@ jobs:
     # Old entries are evicted by GitHub's cache retention policy.
     - name: Save AI summary cache
       if: always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: cache
         key: ai-summary-${{ github.run_id }}
@@ -84,7 +84,7 @@ jobs:
     # Deploys the site to GitHub Pages
     - name: GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v4
+      uses: crazy-max/ghaction-github-pages@v5
       with:
         build_dir: public
       env:

--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.316.0
@@ -37,6 +37,6 @@ jobs:
         "
 
     - name: Upload Sarif output
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: rubocop.sarif

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build an image from Dockerfile
         run: |
@@ -25,6 +25,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
GitHub is deprecating the **Node 20 Actions runtime**. The latest deploy logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache/restore@v4`, `actions/cache/save@v4`, `actions/checkout@v4`, `crazy-max/ghaction-github-pages@v4`.

This bumps every Node-based action to the first major that ships on the **Node 24** runtime, so the pipeline runs on a supported runtime before Node 20 is removed.

## Bumps (all pure Node 20 → Node 24 runtime, no API changes for our usage)
| Action | From | To | Files |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v5** | all 6 workflows |
| `actions/cache/restore` | v4 | **v5** | page.yml |
| `actions/cache/save` | v4 | **v5** | page.yml |
| `crazy-max/ghaction-github-pages` | v4 | **v5** | page.yml |
| `github/codeql-action/*` (init/autobuild/analyze/upload-sarif) | v3 | **v4** | codeql.yml, trivy-analysis.yml, render-test.yml |

I verified each target major's `action.yml` declares `using: node24`, and that the v4→v5 (checkout/cache/pages) and v3→v4 (codeql) release notes contain **no input/API breaking changes** for how we use them — they only require Actions Runner **v2.327.1+**, which GitHub-hosted `ubuntu-latest` already exceeds.

Docker-based actions (`djdefi/gitavscan`, `chabad360/htmlproofer`) run on the Docker runtime, are unaffected by the Node deprecation, and are left as-is.

## Validation
All 6 workflow files pass YAML parsing locally. PR CI exercises `checkout@v5` (all jobs), `codeql-action@v4` (CodeQL/Analyze), and the render test; the `page.yml` deploy actions (`cache@v5`, `ghaction-github-pages@v5`) validate on the post-merge deploy — I'll confirm the Node 20 annotation is gone.
