### PR TITLE
Cache full summary bundle; fix "Cached summary used." placeholder bug

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -396,38 +396,55 @@ def summarize_breaking_news(breaking_news)
   )
 end
 
-def cache_summary(summary)
-  return unless summary && !summary.empty?
-  
+# Cache the full AI summary bundle (overall + per-feed + breaking) as one JSON
+# document so a cache hit can restore every summary and make zero AI calls. The
+# overall summary is stored under `summary` for backward compatibility with
+# older single-summary cache files. Only called when the overall summary is
+# usable (see caller), so a fresh cache never persists an error placeholder.
+def cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
+  return unless overall_summary && !overall_summary.empty?
+
   begin
     FileUtils.mkdir_p('cache')
     File.open(CACHE_FILE, 'w') do |f|
-      f.write({ timestamp: Time.now.utc.iso8601, summary: summary }.to_json)
+      f.write({
+        timestamp: Time.now.utc.iso8601,
+        summary: overall_summary,
+        feed_summaries: feed_summaries || {},
+        breaking_news_summary: breaking_news_summary
+      }.to_json)
     end
-    puts "Summary cached successfully"
+    puts "Summaries cached successfully"
   rescue => e
-    puts "Warning: Failed to cache summary: #{e.message}"
+    puts "Warning: Failed to cache summaries: #{e.message}"
   end
 end
 
-def load_cached_summary
+# Load the cached summary bundle if present and still within the 6h TTL.
+# Returns { 'overall' =>, 'feeds' =>, 'breaking' => } or nil on miss/expiry/
+# error. Older single-summary cache files (just `summary`) still load — the
+# per-feed and breaking parts are simply treated as empty.
+def load_cached_summaries
   # Skip cache if force regeneration is requested
   if ENV['FORCE_REGENERATE'] == 'true'
     puts "Force regeneration enabled, skipping cache"
     return nil
   end
-  
+
   return unless File.exist?(CACHE_FILE)
-  
+
   begin
     data = JSON.parse(File.read(CACHE_FILE))
     timestamp = Time.parse(data['timestamp'])
-    summary = data['summary']
-    
+
     # Check if cache is still valid (6 hours)
     if Time.now.utc - timestamp < 6 * 60 * 60
-      puts "Loaded cached summary from #{timestamp}"
-      summary
+      puts "Loaded cached summaries from #{timestamp}"
+      {
+        'overall' => data['summary'],
+        'feeds' => data['feed_summaries'] || {},
+        'breaking' => data['breaking_news_summary']
+      }
     else
       puts "Cached summary expired, will generate new one"
       nil
@@ -457,24 +474,29 @@ puts ""
 
 feeds = fetch_feeds(rss_urls)
 breaking_news = fetch_yubanet_breaking_news
-breaking_news_summary = summarize_breaking_news(breaking_news)
-cached_summary = load_cached_summary
+cached = load_cached_summaries
 
-if cached_summary
-  overall_summary = cached_summary
-  feed_summaries = feeds.transform_values { |feed| "Cached summary used." }
-  puts "Using cached summary."
+if cached
+  # Reuse every cached summary — a hit makes zero AI calls. (Older caches only
+  # hold the overall summary; the per-feed and breaking sections are omitted
+  # rather than shown as a placeholder.)
+  overall_summary = cached['overall']
+  feed_summaries = cached['feeds'] || {}
+  breaking_news_summary = cached['breaking']
+  puts "Using cached summaries."
 else
   puts "Generating summaries for #{feeds.size} feeds..."
   feed_summaries = feeds.transform_values { |feed| summarize_news(feed) }
   overall_summary = summarize_overall_news(feeds.values)
-  
-  # Only cache if we actually got a useful summary
+  breaking_news_summary = summarize_breaking_news(breaking_news)
+
+  # Only cache if we actually got a useful overall summary, so an error
+  # placeholder never gets persisted for the next 6 hours.
   if overall_summary && !overall_summary.include?("unavailable") && !overall_summary.include?("failed")
-    cache_summary(overall_summary)
-    puts "Generated and cached new summary."
+    cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
+    puts "Generated and cached new summaries."
   else
-    puts "Generated summary but not caching due to errors."
+    puts "Generated summaries but not caching due to errors."
   end
 end
 

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -126,9 +126,38 @@ class RenderTest < Minitest::Test
     output = `FORCE_REGENERATE=false ruby render.rb 2>&1`
     
     # Verify that cache is loaded
-    assert_includes output, "Loaded cached summary", "Cache should be loaded when FORCE_REGENERATE is false"
+    assert_includes output, "Loaded cached summaries", "Cache should be loaded when FORCE_REGENERATE is false"
     
     puts "✓ Force regeneration feature works correctly"
+  ensure
+    FileUtils.rm_f('cache/ai_summary_cache.json')
+  end
+
+  def test_cache_hit_shows_real_summaries_not_placeholder
+    # Regression: a cache hit used to blank every per-feed summary with the
+    # literal string "Cached summary used." and never cached per-feed/breaking
+    # summaries. The bundle cache must restore real summaries instead.
+    load File.expand_path('../render.rb', __dir__)
+    feed_url = 'http://example.com/cache-bundle'
+    FileUtils.mkdir_p('cache')
+    cache_data = {
+      'timestamp' => Time.now.utc.iso8601,
+      'summary' => 'OVERALL_CACHED_MARKER',
+      'feed_summaries' => { feed_url => 'PERFEED_CACHED_MARKER' },
+      'breaking_news_summary' => 'BREAKING_CACHED_MARKER'
+    }.to_json
+    File.write('cache/ai_summary_cache.json', cache_data)
+
+    output = `RSS_URLS=#{feed_url} ruby render.rb 2>&1`
+    html = File.read('public/index.html')
+
+    assert_includes output, "Using cached summaries.", "A fresh cache should be a hit"
+    refute_includes html, "Cached summary used.",
+      "The placeholder must never leak to the rendered page"
+    assert_includes html, "OVERALL_CACHED_MARKER", "Cached overall summary should render"
+    assert_includes html, "PERFEED_CACHED_MARKER", "Cached per-feed summary should render"
+  ensure
+    FileUtils.rm_f('cache/ai_summary_cache.json')
   end
 
   def test_manifest_pwa_settings


### PR DESCRIPTION
## The bug (currently live)
Right now the deployed page shows **`Feed Summary: Cached summary used.`** under every feed — a placeholder string leaking to visitors:

```
$ curl -s https://djdefi.github.io/rss-firehose/ | grep -c "Cached summary used"
3
```

## Root cause
The in-repo AI cache (`cache/ai_summary_cache.json`, 6h TTL) only stored the **overall** summary. So on a cache hit:
- per-feed summaries were replaced with the literal string `"Cached summary used."` and rendered as-is, and
- the breaking-news summary was **regenerated on every run** (it was never cached), so a "hit" still spent one AI call.

Combined with cron (`0 3,15 * * *`, 12h apart) vs the 6h TTL, scheduled runs always miss — so the placeholder only surfaces during bursts of manual/push deploys (like today's), which is exactly why it's live now.

## Fix — cache the whole bundle
Store **overall + per-feed + breaking** as one JSON document:
- `load_cached_summaries` → `{ overall, feeds, breaking }`; a hit now restores **every** summary and makes **zero** AI calls (previously ≥1 every run).
- Real per-feed/breaking summaries render on a hit; the placeholder is removed entirely.
- **Backward compatible:** older single-summary files still load (via the retained `summary` key); their per-feed/breaking sections are simply omitted for one cycle instead of showing a placeholder.
- `cache_summaries` persists all three, still gated on a usable overall summary so an error placeholder is never cached for 6h.
- Breaking-news summarization moved into the cache-miss branch so it's covered by the cache like the rest.

## Tests
- New regression test: a fresh cache is a hit that renders the real cached overall + per-feed markers and **never** emits `"Cached summary used."`.
- Updated the force-regenerate test for the new log wording, with cache-file cleanup.
- **Docker `ruby:4-alpine`: 18 runs, 64 assertions, 0 failures, 3 skips.**

Follow-up (separate PR): pipeline the per-feed + overall + breaking AI calls concurrently on a cache miss (they're currently serial).
