### PR TITLE
Pipeline AI summary calls concurrently; extract shared parallel_map

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -130,43 +130,57 @@ def create_offline_feed(url)
   rss_content
 end
 
-# Fetch and parse all feeds concurrently with a small bounded thread pool.
-# Feeds are independent network I/O, so parallelizing collapses the one-shot's
-# fetch time from the sum of every request to roughly the slowest single feed.
-# Input URL order is preserved and each feed still flows through feed(), so the
-# retry/offline-placeholder behavior is unchanged — only wall-clock time drops.
-# Concurrency is bounded (default 8, override with FEED_CONCURRENCY).
-def fetch_feeds(urls)
-  return {} if urls.empty?
+# Apply the block to each item across a bounded thread pool, returning an
+# (unordered) Hash of { item => block_result }. Used to pipeline the one-shot's
+# independent network I/O — feed fetches and the per-feed/overall/breaking AI
+# summary calls — so wall-clock is roughly the slowest single call instead of
+# the sum of them all. Concurrency is bounded (default 8, override with
+# FEED_CONCURRENCY).
+def parallel_map(items)
+  results = {}
+  return results if items.empty?
 
   max_threads = (ENV['FEED_CONCURRENCY'] || '8').to_i
   max_threads = 1 if max_threads < 1
-  worker_count = [max_threads, urls.size].min
+  worker_count = [max_threads, items.size].min
 
   queue = Queue.new
-  urls.each { |url| queue << url }
-  results = {}
+  items.each { |item| queue << item }
   mutex = Mutex.new
 
   workers = Array.new(worker_count) do
     Thread.new do
       loop do
-        url = begin
+        item = begin
           queue.pop(true)
         rescue ThreadError
           break
         end
-        parsed = begin
-          feed(url)
-        rescue StandardError => e
-          puts "Unexpected error fetching '#{url}': #{e.message}"
-          create_offline_feed(url)
-        end
-        mutex.synchronize { results[url] = parsed }
+        value = yield(item)
+        mutex.synchronize { results[item] = value }
       end
     end
   end
   workers.each(&:join)
+  results
+end
+
+# Fetch and parse all feeds concurrently. Feeds are independent network I/O, so
+# parallelizing collapses the one-shot's fetch time from the sum of every
+# request to roughly the slowest single feed. Input URL order is preserved and
+# each feed still flows through feed(), so the retry/offline-placeholder
+# behavior is unchanged — only wall-clock time drops.
+def fetch_feeds(urls)
+  return {} if urls.empty?
+
+  results = parallel_map(urls) do |url|
+    begin
+      feed(url)
+    rescue StandardError => e
+      puts "Unexpected error fetching '#{url}': #{e.message}"
+      create_offline_feed(url)
+    end
+  end
 
   # Preserve input order and drop nils, matching the previous
   # `rss_urls.map { ... }.to_h.compact` behavior.
@@ -486,9 +500,28 @@ if cached
   puts "Using cached summaries."
 else
   puts "Generating summaries for #{feeds.size} feeds..."
-  feed_summaries = feeds.transform_values { |feed| summarize_news(feed) }
-  overall_summary = summarize_overall_news(feeds.values)
-  breaking_news_summary = summarize_breaking_news(breaking_news)
+
+  # Every summary is an independent GitHub Models request, so pipeline them all
+  # (per-feed + overall + breaking) across the bounded pool instead of making
+  # N+2 serial calls. On a 3-feed run this is 5 HTTP round-trips collapsed from
+  # sequential to roughly one call's wall-clock.
+  jobs = feeds.keys.map { |url| [:feed, url] }
+  jobs << [:overall, nil]
+  jobs << [:breaking, nil]
+
+  summaries = parallel_map(jobs) do |(kind, url)|
+    case kind
+    when :feed     then summarize_news(feeds[url])
+    when :overall  then summarize_overall_news(feeds.values)
+    when :breaking then summarize_breaking_news(breaking_news)
+    end
+  end
+
+  feed_summaries = feeds.keys.each_with_object({}) do |url, acc|
+    acc[url] = summaries[[:feed, url]]
+  end
+  overall_summary = summaries[[:overall, nil]]
+  breaking_news_summary = summaries[[:breaking, nil]]
 
   # Only cache if we actually got a useful overall summary, so an error
   # placeholder never gets persisted for the next 6 hours.

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -258,6 +258,19 @@ class RenderTest < Minitest::Test
       "Ampersand in title should be escaped."
   end
 
+  # --- Bounded parallel map ------------------------------------------------
+
+  def test_parallel_map_empty_returns_empty_hash
+    assert_equal({}, parallel_map([]))
+  end
+
+  def test_parallel_map_applies_block_to_every_item
+    items = (1..20).to_a
+    result = parallel_map(items) { |n| n * n }
+    assert_equal items.size, result.size, "Every item should produce a result"
+    items.each { |n| assert_equal(n * n, result[n], "Item #{n} should be mapped") }
+  end
+
   # --- Concurrent feed fetching -------------------------------------------
 
   def test_fetch_feeds_empty_returns_empty_hash


### PR DESCRIPTION
## Summary
On a cache miss the render made **N+2 serial** GitHub Models requests — one `summarize_news` per feed plus the overall and breaking-news summaries. For the default 3-feed config that's **5 sequential HTTP round-trips** on every scheduled run.

This pipelines them:
- Extracts the bounded thread-pool that `fetch_feeds` hand-rolled into a generic **`parallel_map(items) { ... }`** helper (DRY — one pool implementation, two callers).
- Reuses it to run **all** summary calls (per-feed + overall + breaking) concurrently, collapsing them from sequential to ~one call's wall-clock.

`fetch_feeds` keeps its exact behavior (URL order preserved, nils dropped, per-feed offline fallback), now expressed via `parallel_map`.

## Why
- Cuts deploy wall-clock → **fewer Actions minutes** on the twice-daily cron.
- Directly the "pipelining / reduce N+1" improvement requested.
- Bounded by `FEED_CONCURRENCY` (default 8); 5 concurrent requests twice a day is well within GitHub Models limits, and each `summarize_*` already degrades to a fallback string on error, so a transient failure never crashes the run.

## Safety
Ruby's `$~`/`$1` regex match globals are **thread-local**, and each HTTParty request is independent, so concurrent `format_summary`/`gsub` and POSTs are safe.

## Not doing: YJIT
Considered per the earlier ask. This render is I/O-bound (feed + AI HTTP calls dominate; RSS parse + ERB are trivial CPU) and a short-lived one-shot that rarely reaches YJIT's compile threshold, so enabling it would be cargo-cult with negligible benefit. Skipped deliberately.

## Tests
- New `parallel_map` unit tests (empty hash; maps every one of 20 items through an 8-wide pool).
- **Docker `ruby:4-alpine`: 20 runs, 86 assertions, 0 failures, 3 skips.**
