### PR TITLE
design: fix mobile overflow + crisp 2026 redesign (friendly names, count bars, dark theme)

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -1,53 +1,252 @@
+:root {
+    --bg: #f5f6f8;
+    --surface: #ffffff;
+    --text: #1a1d21;
+    --muted: #5c6570;
+    --border: #e6e8ec;
+    --accent: #d62828;
+    --accent-weak: #fff3f3;
+    --link: #0b5fca;
+    --track: #eceef2;
+    --shadow: 0 1px 2px rgba(16, 24, 40, .05), 0 1px 3px rgba(16, 24, 40, .05);
+    --radius: 14px;
+}
+
 @media (prefers-color-scheme: dark) {
-    body {
-        background-color: #000;
-        filter: invert(1) hue-rotate(180deg)
+    :root {
+        --bg: #0d1117;
+        --surface: #161b22;
+        --text: #e6edf3;
+        --muted: #9198a1;
+        --border: #2a313c;
+        --accent: #ff6b6b;
+        --accent-weak: #241a1c;
+        --link: #6cb6ff;
+        --track: #21262d;
+        --shadow: 0 1px 2px rgba(0, 0, 0, .3);
     }
 }
 
-body,
+*,
+::before,
+::after {
+    box-sizing: border-box;
+}
+
 html {
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    width: 100%
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-}
-
-*,
-:after,
-:before {
-    box-sizing: border-box
-}
-
-hr {
-    height: 1px;
-    background-color: #efefef;
-    border: 0;
     margin: 0;
-    padding: 0
+    background-color: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 16px;
+    line-height: 1.6;
+}
+
+/* Long URLs / unbroken tokens must wrap instead of forcing horizontal scroll. */
+a,
+p,
+li,
+h1,
+h2,
+h3,
+h4 {
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.container {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 0 16px 48px;
+}
+
+a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Header */
+.site-header {
+    padding: 28px 0 16px;
+}
+
+.site-title {
+    margin: 0;
+    color: var(--accent);
+    font-size: 1.9rem;
+    font-weight: 800;
+    letter-spacing: -.02em;
+}
+
+.site-meta {
+    margin: 4px 0 14px;
+    color: var(--muted);
+    font-size: .9rem;
+}
+
+.stat-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    padding: 4px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--muted);
+    font-size: .82rem;
+    white-space: nowrap;
+}
+
+.chip strong {
+    color: var(--text);
+    font-size: .9rem;
+}
+
+.chip-alert {
+    border-color: var(--accent);
+}
+
+.chip-alert,
+.chip-alert strong {
+    color: var(--accent);
+}
+
+/* Cards */
+.card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 18px 20px;
+    margin: 16px 0;
+}
+
+.card h2 {
+    margin-top: 0;
+}
+
+h2 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    letter-spacing: -.01em;
+}
+
+h3 {
+    font-size: 1.05rem;
+}
+
+.section-heading {
+    margin: 28px 0 4px;
+}
+
+.alert {
+    color: var(--accent);
+}
+
+/* AI summary callout */
+.ai-summary {
+    margin: 14px 0;
+    padding: 12px 16px;
+    background: var(--accent-weak);
+    border-left: 4px solid var(--accent);
+    border-radius: 8px;
+}
+
+.ai-summary h3 {
+    margin: 0 0 6px;
+    color: var(--accent);
+    font-size: 1rem;
+}
+
+.ai-summary p {
+    margin: 0;
+}
+
+/* Feed summary callout */
+.feed-summary {
+    margin: 10px 0;
+    padding: 10px 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.feed-summary h4 {
+    margin: 0 0 4px;
+    font-size: .9rem;
+    color: var(--muted);
+}
+
+.feed-summary p {
+    margin: 0;
+}
+
+/* Feed / source heading + count bar */
+.feed-link {
+    margin: 0 0 8px;
+}
+
+.feed-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.count {
+    color: var(--muted);
+    font-size: .82rem;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.bar {
+    flex: 1;
+    max-width: 240px;
+    height: 6px;
+    background: var(--track);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.bar-fill {
+    display: block;
+    height: 100%;
+    min-width: 4px;
+    background: var(--accent);
+    border-radius: 999px;
+}
+
+/* Lists */
+ul {
+    margin: 6px 0 0;
+    padding-left: 1.2rem;
 }
 
 li {
-    padding: 5px
+    padding: 3px 0;
 }
 
-.firehose {
-    padding: 20px
-}
-
-.firehose>ul {
-    padding-left: 10px;
-    margin: 10px 0
-}
-
-.firehose>p:first-of-type {
-    margin-top: 0
-}
-
-.firehose>p:last-of-type {
-    margin-bottom: 0
+.news-list strong {
+    color: var(--muted);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
 }

--- a/render.rb
+++ b/render.rb
@@ -29,6 +29,11 @@ PLACEHOLDER_SUMMARIES = [
   'No articles available for summarization.'
 ].freeze
 
+# Maximum length of a friendly feed name before it is truncated with an
+# ellipsis (see feed_display_name), so a long channel title can't dominate the
+# layout or reintroduce horizontal overflow on narrow screens.
+FEED_NAME_MAX = 40
+
 def title
   title = ENV['RSS_TITLE'] || 'News Firehose'
   title.strip.empty? ? 'News Firehose' : title
@@ -264,6 +269,31 @@ end
 def safe_url(url)
   str = url.to_s.strip
   str.match?(%r{\A(?:https?://|ftp://|mailto:|//|/|\#)}i) ? str : '#'
+end
+
+# Bare hostname for a feed URL: strips scheme, leading "www." and any path, so
+# "https://www.example.com/rss?x=1" becomes "example.com". Falls back to the
+# original string if stripping leaves it empty.
+def feed_host(url)
+  host = url.to_s.sub(%r{\Ahttps?://}i, '').sub(/\Awww\./i, '').sub(%r{/.*\z}m, '')
+  host.empty? ? url.to_s : host
+end
+
+# Friendly, short label for a feed source shown in the rendered page: prefer the
+# RSS channel title (e.g. "YubaNet"), falling back to the bare hostname when the
+# title is missing, the feed is offline, the title itself looks like a URL/domain
+# (some feeds title themselves "www.example.com - RSS Results ..."), or the title
+# is unreasonably long. Keeps the listing clean and avoids long raw URLs
+# overflowing mobile viewports.
+def feed_display_name(url, parsed)
+  title = (parsed.channel.title.to_s.strip if parsed.respond_to?(:channel) && parsed.channel)
+  return feed_host(url) if title.nil? || title.empty? ||
+                           title == FEED_OFFLINE_TITLE ||
+                           title.match?(%r{\A(?:https?://|www\.)}i)
+
+  title.length > FEED_NAME_MAX ? "#{title[0, FEED_NAME_MAX].rstrip}…" : title
+rescue StandardError
+  feed_host(url)
 end
 
 def sanitize_response(response_body)

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -3,7 +3,8 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="theme-color" content="#efefef">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f6f8">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0d1117">
   <link rel="icon" sizes="192x192" href="img/icon.png">
   <link rel="apple-touch-icon" href="img/icon.png">
   <link type="text/css" rel="stylesheet" href="main.css"/>
@@ -12,53 +13,65 @@
   <meta name="description" content="<%= description %>"/>
 </head>
 <body>
-<div role="main">
-  <header style="padding:10px;">
-    <h1 style="color:#c00;" aria-label="Page Title"><%= title %></h1>
-    <p aria-label="Current Date and Time"><%= Time.now.strftime('%F %R %Z') -%></p>
+<main class="container">
+  <header class="site-header">
+    <h1 class="site-title" aria-label="Page Title"><%= title %></h1>
+    <p class="site-meta" aria-label="Last updated">Updated <%= Time.now.strftime('%F %R %Z') -%></p>
+    <ul class="stat-chips" aria-label="Feed statistics">
+      <li class="chip"><strong><%= feeds.size %></strong> <%= feeds.size == 1 ? 'feed' : 'feeds' %></li>
+      <li class="chip"><strong><%= feeds.sum { |_url, parsed| parsed.items.count } %></strong> stories</li>
+      <% if defined?(breaking_news) && breaking_news && !breaking_news.empty? %>
+      <li class="chip chip-alert"><strong><%= breaking_news.size %></strong> breaking</li>
+      <% end %>
+    </ul>
   </header>
-  <hr/>
+
   <% if overall_summary && !overall_summary.empty? %>
-  <section class="overall-summary" style="padding:10px;" aria-labelledby="overall-summary-title">
+  <section class="card overall-summary" aria-labelledby="overall-summary-title">
     <h2 id="overall-summary-title">Overall Summary</h2>
     <p><%= overall_summary %></p>
   </section>
-  <hr/>
   <% end %>
+
   <% if defined?(breaking_news) && breaking_news && !breaking_news.empty? %>
-  <section class="breaking-news" style="padding:10px;" aria-labelledby="breaking-news-title">
-    <h2 id="breaking-news-title" style="color:#c00;">🚨 Breaking News - YubaNet Live Updates</h2>
+  <section class="card breaking-news" aria-labelledby="breaking-news-title">
+    <h2 id="breaking-news-title" class="alert">🚨 Breaking News - YubaNet Live Updates</h2>
     <% if defined?(breaking_news_summary) && breaking_news_summary && !breaking_news_summary.include?("unavailable") && !breaking_news_summary.include?("failed") %>
-    <div style="background-color:#fff5f5; border-left:4px solid #c00; padding:10px; margin:10px 0;">
-      <h3 style="margin-top:0; color:#c00;">AI Summary</h3>
+    <div class="ai-summary">
+      <h3>AI Summary</h3>
       <p><%= breaking_news_summary %></p>
     </div>
     <% end %>
-    <div>
-      <h3>
-        <a href='https://yubanet.com/featured/now/' aria-label="YubaNet Breaking News">yubanet.com/featured/now - <%= breaking_news.size %> recent updates:</a>
-      </h3>
-      <ul>
-        <% breaking_news.first(10).each do |news_item| -%>
-          <li>
-            <strong><%= html_escape(news_item[:timestamp]) %></strong>: 
-            <a href='<%= html_escape(safe_url(news_item[:link])) %>' aria-label="Breaking News Item"><%= html_escape(news_item[:content]) %></a>
-          </li>
-        <% end -%>
-      </ul>
-    </div>
+    <h3 class="feed-link">
+      <a href='https://yubanet.com/featured/now/' aria-label="YubaNet Breaking News">yubanet.com/featured/now - <%= breaking_news.size %> recent updates</a>
+    </h3>
+    <ul class="news-list">
+      <% breaking_news.first(10).each do |news_item| -%>
+        <li>
+          <strong><%= html_escape(news_item[:timestamp]) %></strong>
+          <a href='<%= html_escape(safe_url(news_item[:link])) %>' aria-label="Breaking News Item"><%= html_escape(news_item[:content]) %></a>
+        </li>
+      <% end -%>
+    </ul>
   </section>
-  <hr/>
   <% end %>
-  <section class="firehose" style="padding:10px;" aria-labelledby="stories-title">
-    <h2 id="stories-title">Stories</h2>
-    <div>
-      <% feeds.each do |url, parsed| -%>
-        <h3>
-          <a href='<%= url.gsub '/feed/', '' %>' aria-label="Feed URL"><%= url.gsub '/feed/', '' %> - <%= parsed.items.count %> items:</a>
+
+  <section class="firehose" aria-labelledby="stories-title">
+    <h2 id="stories-title" class="section-heading">Stories</h2>
+    <% max_items = feeds.map { |_url, parsed| parsed.items.count }.max.to_i %>
+    <% max_items = 1 if max_items < 1 %>
+    <% feeds.each do |url, parsed| -%>
+      <% count = parsed.items.count -%>
+      <div class="card feed">
+        <h3 class="feed-link">
+          <a href='<%= html_escape(safe_url("https://#{feed_host(url)}/")) %>' aria-label="Feed source"><%= html_escape(feed_display_name(url, parsed)) %></a>
         </h3>
+        <div class="feed-meta">
+          <span class="count"><%= count %> <%= count == 1 ? 'item' : 'items' %></span>
+          <span class="bar" aria-hidden="true"><span class="bar-fill" style="width: <%= (count.to_f / max_items * 100).round %>%"></span></span>
+        </div>
         <% if feed_summaries[url] && !feed_summaries[url].empty? %>
-        <div class="feed-summary" style="padding:10px;" aria-labelledby="feed-summary-title-<%= url %>">
+        <div class="feed-summary" aria-labelledby="feed-summary-title-<%= url %>">
           <h4 id="feed-summary-title-<%= url %>">Feed Summary</h4>
           <p><%= feed_summaries[url] %></p>
         </div>
@@ -70,10 +83,10 @@
             </li>
           <% end -%>
         </ul>
-      <% end -%>
-    </div>
+      </div>
+    <% end -%>
   </section>
-</div>
+</main>
 
 <% if analytics_ua %>
 <script>

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -233,6 +233,59 @@ class RenderTest < Minitest::Test
     assert_equal "#", safe_url("vbscript:msgbox(1)")
   end
 
+  def test_feed_host_strips_scheme_www_and_path
+    assert_equal "example.com", feed_host("https://www.example.com/rss?x=1")
+    assert_equal "yubanet.com", feed_host("https://yubanet.com/feed/")
+    assert_equal "theunion.com", feed_host("https://www.theunion.com/search/?f=rss&t=article&c=news")
+    # Nothing to strip: returns the original rather than an empty string.
+    assert_equal "not a url", feed_host("not a url")
+  end
+
+  def test_feed_display_name_prefers_channel_title
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>YubaNet</title><link>http://x</link>
+      <description>d</description>
+      <item><title>t</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    assert_equal "YubaNet", feed_display_name("https://yubanet.com/feed/", rss)
+  end
+
+  def test_feed_display_name_falls_back_to_host_for_offline_feed
+    url = "https://www.theunion.com/search/?f=rss&t=article&c=news"
+    offline = create_offline_feed(url)
+    assert_equal "theunion.com", feed_display_name(url, offline),
+                 "Offline feeds must show a friendly hostname, not the offline placeholder title"
+  end
+
+  def test_feed_display_name_falls_back_to_host_for_url_like_title
+    # Some feeds title themselves after their URL (e.g. theunion's RSS search).
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>www.theunion.com - RSS Results in news only</title>
+      <link>http://x</link><description>d</description>
+      <item><title>t</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    assert_equal "theunion.com",
+                 feed_display_name("https://www.theunion.com/search/?f=rss&t=article&c=news", rss),
+                 "URL-like channel titles must fall back to the clean hostname"
+  end
+
+  def test_feed_display_name_truncates_overlong_title
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>#{'A' * 60}</title><link>http://x</link>
+      <description>d</description>
+      <item><title>t</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    name = feed_display_name("https://x.test/feed/", rss)
+    assert name.length <= FEED_NAME_MAX + 1, "Overlong titles must be truncated near FEED_NAME_MAX"
+    assert name.end_with?("…"), "Truncated names must end with an ellipsis"
+  end
+
   def test_render_escapes_malicious_feed_content
     feed = RSS::Parser.parse(<<~XML, false)
       <?xml version="1.0"?>


### PR DESCRIPTION
## What

Fixes the mobile (iOS) horizontal scroll and gives the page a clean, crisp 2026 refresh — while staying lightweight: **one hand-maintained CSS file, zero JavaScript, zero external requests/fonts**.

## The mobile bug (root cause + fix)

Feed headings rendered the **raw feed URL** as unbreakable link text (e.g. `https://www.mynevadacounty.com/RSSFeed.aspx?ModID=1&CID=All-newsflash.xml`). The stylesheet had **no word-wrapping rules at all**, so that token forced the page wider than the viewport.

Measured at a 390px iPhone viewport on the real rendered page:

| | Before | After |
|---|---|---|
| document scrollWidth | 466px | 390px |
| horizontal overflow | **76px** | **0px** |
| offending elements | 1 (feed URL `<a>`) | 0 |

Fix: `overflow-wrap: break-word` on text elements **and** switching feed headings to friendly names (below), so long raw URLs are gone from the display entirely.

## Friendly feed names

New `feed_host` / `feed_display_name` helpers in `render.rb`: show the RSS **channel title** (e.g. `YubaNet`), falling back to the bare **hostname** when the title is missing, the feed is offline, the title *looks like a URL* (theunion titles itself `www.theunion.com - RSS Results ...`), or it's too long.

Live result: `YubaNet` · `theunion.com` · `Nevada County, CA - News Flash` (was three long raw URLs).

## Clean / crisp redesign

- **Card-based** sections on a soft background, subtle borders + shadow, rounded corners.
- **Centered 760px reading column** (desktop lines were previously edge-to-edge and hard to read).
- **CSS custom properties + a real light/dark theme** — replaces the old `filter: invert()` hack that also inverted the 🚨 emoji and app icons.
- **Lightweight engaging visuals, no dependencies:**
  - per-feed **item-count bars** (a tiny horizontal bar chart, width ∝ item count)
  - header **stat chips**: `N feeds · N stories · N breaking`
- Two `theme-color` metas (light/dark), `<main>` landmark, preserved ARIA labels.

## Tests / validation

- New unit tests for `feed_host` + `feed_display_name` (channel title, hostname fallback, offline feed, URL-like title, truncation).
- Full suite (Ruby 4, Docker): **32 runs, 127 assertions, 0 failures, 0 skips.**
- Verified 0px overflow and the redesign in light **and** dark at 390px and 1200px via a headless browser against the real rendered `index.html`.

No runtime/behavioral change to fetching, caching, or summarization; `public/main.css` is the only shipped asset touched (the page HTML is regenerated by the deploy).
