### PR TITLE
Add KNCO feed + NWS critical weather-alert band

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -161,6 +161,56 @@ h3 {
     color: var(--accent);
 }
 
+/* Critical weather-alert band (NWS) — only rendered when alerts are active.
+   No animation/flash (accessibility): a solid accent border carries urgency. */
+.alert-band {
+    border-color: var(--accent);
+    border-left: 5px solid var(--accent);
+    background: var(--accent-weak);
+}
+
+.alert-title {
+    color: var(--accent);
+}
+
+.alert-list {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+}
+
+.alert-list li {
+    padding: 8px 0;
+    border-top: 1px solid var(--border);
+}
+
+.alert-list li:first-child {
+    border-top: 0;
+}
+
+.alert-event {
+    font-weight: 700;
+    color: var(--accent);
+    margin-right: 8px;
+}
+
+.alert-area {
+    font-weight: 600;
+}
+
+.alert-detail {
+    display: block;
+    color: var(--muted);
+    font-size: .92rem;
+    margin-top: 2px;
+}
+
+.alert-source {
+    margin: 10px 0 0;
+    font-size: .82rem;
+    color: var(--muted);
+}
+
 /* AI summary callout */
 .ai-summary {
     margin: 14px 0;

--- a/render.rb
+++ b/render.rb
@@ -40,6 +40,26 @@ FEED_NAME_MAX = 40
 # breadth as well as depth.
 ITEM_DESC_MAX = 240
 
+# National Weather Service active-alerts API + the zone to watch. CAC057 is
+# Nevada County, CA (covers Nevada City, Grass Valley and Truckee); override
+# with NWS_ALERT_ZONE (any NWS county "CACnnn" or forecast/fire "CAZnnn" UGC).
+# The band is the "high-signal, only-when-active" critical strip: it renders
+# nothing when there are no qualifying alerts. NWS requires a descriptive
+# User-Agent or it returns 403.
+NWS_ALERTS_ENDPOINT = 'https://api.weather.gov/alerts/active'
+NWS_ALERT_ZONE = (ENV['NWS_ALERT_ZONE'] || 'CAC057').strip
+NWS_USER_AGENT = 'rss-firehose (https://github.com/djdefi/rss-firehose)'
+
+# Only genuinely critical, actionable alerts belong in the band. Keep an alert
+# if its severity is Severe/Extreme (NWS "Warnings") or its event matches one
+# of these life-safety types, so routine advisories (Lake Wind, Heat Advisory)
+# are filtered out.
+NWS_CRITICAL_EVENTS = /red flag|fire warning|fire weather|evacuation|flood|tornado|tsunami|hurricane|extreme|blizzard|severe thunderstorm/i
+NWS_CRITICAL_SEVERITIES = %w[Severe Extreme].freeze
+# Cap how many alerts the band lists, newest first, so a busy alert day can't
+# push the actual news far down the page.
+NWS_ALERT_MAX = 6
+
 def title
   title = ENV['RSS_TITLE'] || 'News Firehose'
   title.strip.empty? ? 'News Firehose' : title
@@ -89,7 +109,7 @@ def analytics_ua
   ENV['ANALYTICS_UA']
 end
 
-def render_html(feeds, overall_summary, feed_summaries, breaking_news = [], breaking_news_summary = nil)
+def render_html(feeds, overall_summary, feed_summaries, breaking_news = [], breaking_news_summary = nil, weather_alerts = [])
   begin
     html = File.open('templates/index.html.erb').read
     template = ERB.new(html, trim_mode: '-')
@@ -528,6 +548,67 @@ def summarize_breaking_news(breaking_news)
   )
 end
 
+# Turn an NWS active-alerts API JSON body into a compact, escaped-later list of
+# critical alerts. Pure (no I/O) so it can be unit-tested against fixture JSON.
+# Keeps only genuinely critical alerts (see NWS_CRITICAL_* ) so routine
+# advisories don't dilute the band, dedupes repeated events, and caps the count.
+def parse_weather_alerts(json_body)
+  data = JSON.parse(json_body.to_s)
+  features = data['features']
+  return [] unless features.is_a?(Array)
+
+  alerts = features.filter_map do |feature|
+    props = feature['properties']
+    next unless props.is_a?(Hash)
+
+    event = props['event'].to_s.strip
+    next if event.empty?
+
+    severity = props['severity'].to_s
+    next unless NWS_CRITICAL_SEVERITIES.include?(severity) || event.match?(NWS_CRITICAL_EVENTS)
+
+    {
+      event: event,
+      headline: props['headline'].to_s.strip,
+      area: props['areaDesc'].to_s.strip,
+      severity: severity,
+      expires: props['expires'].to_s.strip
+    }
+  end
+
+  alerts.uniq { |a| [a[:event], a[:area]] }.first(NWS_ALERT_MAX)
+rescue JSON::ParserError => e
+  puts "Error parsing weather alerts: #{e.message}"
+  []
+end
+
+# Fetch active NWS alerts for a zone and return the critical subset. Always
+# fetched fresh (alerts are time-sensitive, so they are never cached with the
+# 6-hour AI bundle) and fails soft to [] so a NWS outage never breaks the page.
+def fetch_weather_alerts(zone = NWS_ALERT_ZONE)
+  return [] if zone.nil? || zone.empty?
+
+  response = HTTParty.get(
+    "#{NWS_ALERTS_ENDPOINT}?zone=#{CGI.escape(zone)}",
+    timeout: 30,
+    headers: { 'User-Agent' => NWS_USER_AGENT, 'Accept' => 'application/geo+json' }
+  )
+  unless response.code == 200
+    puts "Failed to fetch NWS alerts for #{zone}: HTTP #{response.code}"
+    return []
+  end
+
+  alerts = parse_weather_alerts(response.body)
+  puts "Fetched #{alerts.size} critical NWS alert(s) for #{zone}"
+  alerts
+rescue HTTParty::Error => e
+  puts "HTTP error fetching NWS alerts: #{e.message}"
+  []
+rescue => e
+  puts "General error fetching NWS alerts: #{e.message}"
+  []
+end
+
 # Cache the full AI summary bundle (overall + per-feed + breaking) as one JSON
 # document so a cache hit can restore every summary and make zero AI calls. The
 # overall summary is stored under `summary` for backward compatibility with
@@ -606,6 +687,7 @@ puts ""
 
 feeds = fetch_feeds(rss_urls)
 breaking_news = fetch_yubanet_breaking_news
+weather_alerts = fetch_weather_alerts
 cached = load_cached_summaries
 
 if cached
@@ -656,7 +738,7 @@ puts "Overall Summary: #{overall_summary}"
 
 begin
   render_manifest
-  render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary)
+  render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary, weather_alerts)
   puts "Successfully rendered HTML and manifest files."
 rescue => e
   puts "Error during rendering process: #{e.message}"

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -26,6 +26,22 @@
     </ul>
   </header>
 
+  <% if defined?(weather_alerts) && weather_alerts && !weather_alerts.empty? %>
+  <section class="card alert-band" aria-labelledby="alerts-title" role="alert">
+    <h2 id="alerts-title" class="alert-title">⚠️ Active Weather Alerts</h2>
+    <ul class="alert-list">
+      <% weather_alerts.each do |wa| -%>
+        <li>
+          <span class="alert-event"><%= html_escape(wa[:event]) %></span>
+          <% unless wa[:area].to_s.strip.empty? -%><span class="alert-area"><%= html_escape(wa[:area]) %></span><% end -%>
+          <% unless wa[:headline].to_s.strip.empty? -%><span class="alert-detail"><%= html_escape(wa[:headline]) %></span><% end -%>
+        </li>
+      <% end -%>
+    </ul>
+    <p class="alert-source">via <a href="https://www.weather.gov/" aria-label="National Weather Service">National Weather Service</a></p>
+  </section>
+  <% end %>
+
   <% if overall_summary && !overall_summary.empty? %>
   <section class="card overall-summary" aria-labelledby="overall-summary-title">
     <h2 id="overall-summary-title">Overall Summary</h2>

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -282,6 +282,64 @@ class RenderTest < Minitest::Test
                     "Raw feed URLs must not be sent to the summarizer"
   end
 
+  # --- NWS critical weather-alert band -------------------------------------
+
+  def test_parse_weather_alerts_keeps_critical_drops_advisories
+    json = {
+      features: [
+        { properties: { event: "Red Flag Warning", severity: "Severe",
+                        headline: "Red Flag Warning until 11 PM", areaDesc: "Western Nevada County",
+                        expires: "2026-07-06T23:00:00-07:00" } },
+        { properties: { event: "Lake Wind Advisory", severity: "Moderate",
+                        headline: "Lake Wind Advisory", areaDesc: "Lake Tahoe", expires: "" } },
+        { properties: { event: "Evacuation Warning", severity: "Unknown",
+                        headline: "Evac warning", areaDesc: "Zone 3", expires: "" } }
+      ]
+    }.to_json
+    events = parse_weather_alerts(json).map { |a| a[:event] }
+    assert_includes events, "Red Flag Warning", "Severe-severity warnings must be kept"
+    assert_includes events, "Evacuation Warning", "life-safety events are kept even at Unknown severity"
+    refute_includes events, "Lake Wind Advisory", "routine advisories must be filtered out"
+  end
+
+  def test_parse_weather_alerts_handles_empty_and_malformed
+    assert_equal [], parse_weather_alerts('{"features":[]}')
+    assert_equal [], parse_weather_alerts('not json at all')
+    assert_equal [], parse_weather_alerts('{}')
+  end
+
+  def test_parse_weather_alerts_dedupes_and_caps
+    dupes = Array.new(4) do
+      { properties: { event: "Flood Warning", severity: "Severe", areaDesc: "Same Area", headline: "h", expires: "" } }
+    end
+    assert_equal 1, parse_weather_alerts({ features: dupes }.to_json).size,
+                 "identical event+area alerts must dedupe"
+
+    many = Array.new(NWS_ALERT_MAX + 3) do |i|
+      { properties: { event: "Flood Warning", severity: "Severe", areaDesc: "Area #{i}", headline: "h", expires: "" } }
+    end
+    assert_equal NWS_ALERT_MAX, parse_weather_alerts({ features: many }.to_json).size,
+                 "the band must cap the number of listed alerts"
+  end
+
+  def test_render_includes_and_escapes_weather_alert_band
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>C</title><link>http://x</link>
+      <description>d</description>
+      <item><title>t</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    alerts = [{ event: "Red Flag Warning <script>", area: "Zone & County",
+                headline: "Until 11 PM", severity: "Severe", expires: "" }]
+    render_html({ "http://x/feed" => feed }, "Overall", {}, [], nil, alerts)
+    output = File.read('public/index.html')
+    assert_includes output, "Active Weather Alerts", "band must render when alerts are present"
+    assert_includes output, "Red Flag Warning &lt;script&gt;", "alert event must be HTML-escaped"
+    assert_includes output, "Zone &amp; County", "alert area must be HTML-escaped"
+    refute_includes output, "Red Flag Warning <script>", "no unescaped alert markup may leak"
+  end
+
   def test_safe_url_allows_safe_and_blocks_dangerous_schemes
     assert_equal "https://ok.test/a", safe_url("https://ok.test/a")
     assert_equal "http://ok.test", safe_url("http://ok.test")

--- a/urls.txt
+++ b/urls.txt
@@ -1,3 +1,4 @@
 https://yubanet.com/feed/
 https://www.theunion.com/search/?f=rss&t=article&c=news
 https://www.mynevadacounty.com/RSSFeed.aspx?ModID=1&CID=All-newsflash.xml
+https://www.knco.com/feed/


### PR DESCRIPTION
Regional coverage plus a **high-signal, only-when-active** safety strip for the Nevada County / Truckee / Tahoe area this fire season — with **no added AI cost**.

## Feeds
- Add `https://www.knco.com/feed/` (KNCO NewsTalk 830, Grass Valley) to `urls.txt`. Verified live: 200 + valid RSS, 10 items. Renders via the existing friendly-name path (no raw URL shown to the user).

## NWS critical-alert band
A conditional band that renders **only when there are active, genuinely critical alerts** for the watched zone — otherwise it's completely hidden, so the page stays clean on normal days.

- **`parse_weather_alerts(json_body)`** — pure/testable. Parses the [NWS active-alerts API](https://api.weather.gov/alerts/active), keeps only critical alerts (severity `Severe`/`Extreme`, or life-safety events: red flag, fire, evacuation, flood, tornado, tsunami, hurricane, extreme, blizzard, severe thunderstorm), dedupes by `[event, area]`, caps at `NWS_ALERT_MAX` (6). Fails soft to `[]` on malformed JSON.
- **`fetch_weather_alerts(zone = NWS_ALERT_ZONE)`** — I/O wrapper. Zone defaults to `CAC057` (Nevada County — covers Nevada City, Grass Valley, **Truckee**); override with `NWS_ALERT_ZONE` (any `CACnnn` county or `CAZnnn` forecast/fire UGC). Sends the descriptive `User-Agent` NWS requires (it 403s without one). **Never cached** (alerts are time-sensitive) but cheap: one GET per run, no AI call. Fails soft to `[]` so an NWS outage never breaks the page.
- **Template** — conditional `<section class="alert-band" role="alert">` after the header; every field `html_escape`'d.
- **CSS** — a solid accent border carries urgency; **no animation/flash** (photosensitivity accessibility). Verified light + dark, **0px mobile overflow at 390px**.

## Why filtered, not all alerts
The statewide feed is full of routine advisories (Lake Wind, Heat Advisory). Live-verified the filter drops those and keeps only actionable warnings (e.g. it kept "Extreme Heat Warning" and dropped a "Lake Wind Advisory" when tested against live `area=CA` data).

## Testing
New tests: filter keeps-critical/drops-advisories, empty/malformed handling, dedupe + cap, and render+escape. **Full suite: 41 runs / 156 assertions / 0 failures.** Validated in Docker `ruby:4-alpine`. `CAC057` currently has 0 active alerts, so the band is hidden live — the expected clean baseline.