### PR TITLE
Remove KNCO feed: blocked from GitHub Actions runner IPs

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -1,4 +1,3 @@
 https://yubanet.com/feed/
 https://www.theunion.com/search/?f=rss&t=article&c=news
 https://www.mynevadacounty.com/RSSFeed.aspx?ModID=1&CID=All-newsflash.xml
-https://www.knco.com/feed/


### PR DESCRIPTION
Follow-up to #211. KNCO is dead in the environment that actually matters — the GitHub Actions runner — so it's removed to keep the aggregator reliable.

## What happened
KNCO (`knco.com`) returns **200 + 10 valid RSS items** from residential IPs (verified via both `curl` and the app's own HTTParty `fetch_and_parse_feed`), so my local pre-merge check passed. But the **first deploy after #211** logged:

```
Feed from 'https://www.knco.com/feed/' returned no items, retrying once...
Feed from 'https://www.knco.com/feed/' failed after retry; using offline placeholder.
```

…while all three other feeds succeeded. This is **datacenter-IP bot-blocking**: the www → non-www 301 is followed fine and it is not a UA issue — the block is on GitHub's IP range. It is the same failure mode that intermittently hits `theunion.com` and that already disqualified Sierra Sun / Tahoe Daily Tribune / GV Wire.

## Why remove rather than keep
A permanently-offline feed only adds a failed fetch + retry every run and an offline placeholder card for **zero reader value** — the opposite of "lightweight and reliable."

## What stays
The **NWS critical-alert band** from #211 is unaffected: `api.weather.gov` is not IP-blocked and fetched cleanly from the runner (`Fetched 0 critical NWS alert(s) for CAC057`).

**Lesson:** candidate feeds must be verified from the Actions runner, not a residential IP — local `curl` gives false positives here.
