### PR TITLE
feat: add a lightweight Regional & Fire secondary page

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -61,6 +61,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.API_TOKEN }}
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}
+        RENDER_REGIONAL: '1' # Also build public/regional.html from urls-regional.txt
 
     # Saves the AI summary cache under a fresh per-run key so it always updates.
     # Old entries are evicted by GitHub's cache retention policy.

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ build-iPhoneSimulator/
 
 /public/manifest.json
 /public/index.html
+/public/regional.html
 /cache/

--- a/public/main.css
+++ b/public/main.css
@@ -93,6 +93,29 @@ a:hover {
     font-size: .9rem;
 }
 
+.page-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 0 14px;
+}
+
+.page-nav a {
+    padding: 4px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--muted);
+    font-size: .82rem;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.page-nav a:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
 .stat-chips {
     display: flex;
     flex-wrap: wrap;

--- a/render.rb
+++ b/render.rb
@@ -122,6 +122,23 @@ def rss_backup_urls
   urls.select { |url| url.match?(/\Ahttps?:\/\//) }
 end
 
+# Feeds for the secondary "Regional & Fire" page (Truckee/Tahoe outlets +
+# InciWeb fire incidents). Kept off the lean main page and off by default so
+# the test suite stays hermetic/fast: enabled only when RSS_REGIONAL_URLS is set
+# (comma-separated, takes precedence) or RENDER_REGIONAL=1 selects urls-regional.txt.
+# The deploy workflow sets RENDER_REGIONAL=1. Every listed feed must be
+# runner-verified (many regional feeds are datacenter-IP-blocked).
+def regional_urls
+  raw = if ENV['RSS_REGIONAL_URLS']
+          ENV['RSS_REGIONAL_URLS'].split(',')
+        elsif ENV['RENDER_REGIONAL'] == '1' && File.exist?('urls-regional.txt')
+          File.readlines('urls-regional.txt')
+        else
+          []
+        end
+  raw.map(&:strip).reject(&:empty?).select { |url| url.match?(%r{\Ahttps?://}i) }
+end
+
 def description
   desc = ENV['RSS_DESCRIPTION'] || 'View the latest news.'
   desc.strip.empty? ? 'View the latest news.' : desc
@@ -131,11 +148,16 @@ def analytics_ua
   ENV['ANALYTICS_UA']
 end
 
-def render_html(feeds, overall_summary, feed_summaries, breaking_news = [], breaking_news_summary = nil, weather_alerts = [])
+# Render a feed page from the shared template. output_path/page_title/nav_links
+# let the same template drive both the main index and the secondary regional
+# page; on the main page they default so the output is unchanged. nav_links is
+# an array of [label, href] pairs rendered as a small inter-page nav.
+def render_html(feeds, overall_summary, feed_summaries, breaking_news = [], breaking_news_summary = nil, weather_alerts = [],
+                output_path: 'public/index.html', page_title: nil, nav_links: nil)
   begin
     html = File.open('templates/index.html.erb').read
     template = ERB.new(html, trim_mode: '-')
-    File.open('public/index.html', 'w') do |f|
+    File.open(output_path, 'w') do |f|
       f.puts template.result(binding)
     end
   rescue => e
@@ -816,7 +838,21 @@ puts "Overall Summary: #{overall_summary}"
 
 begin
   render_manifest
-  render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary, weather_alerts)
+
+  regional = regional_urls
+  main_nav = regional.any? ? [['Main firehose', './'], ['Regional & Fire', 'regional.html']] : nil
+  render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary, weather_alerts,
+              nav_links: main_nav)
+
+  if regional.any?
+    puts "Rendering regional page for #{regional.size} feeds..."
+    regional_feeds = fetch_feeds(regional)
+    render_html(regional_feeds, nil, {}, [], nil, [],
+                output_path: 'public/regional.html',
+                page_title: "#{title} · Regional & Fire",
+                nav_links: [['Main firehose', './'], ['Regional & Fire', 'regional.html']])
+  end
+
   puts "Successfully rendered HTML and manifest files."
 rescue => e
   puts "Error during rendering process: #{e.message}"

--- a/render.rb
+++ b/render.rb
@@ -148,12 +148,12 @@ def analytics_ua
   ENV['ANALYTICS_UA']
 end
 
-# Render a feed page from the shared template. output_path/page_title/nav_links
+# Render a feed page from the shared template. output_path/page_title/show_nav
 # let the same template drive both the main index and the secondary regional
-# page; on the main page they default so the output is unchanged. nav_links is
-# an array of [label, href] pairs rendered as a small inter-page nav.
+# page; on the main page they default so the output is unchanged. show_nav emits
+# the small two-link inter-page nav (static text, so it passes a11y linting).
 def render_html(feeds, overall_summary, feed_summaries, breaking_news = [], breaking_news_summary = nil, weather_alerts = [],
-                output_path: 'public/index.html', page_title: nil, nav_links: nil)
+                output_path: 'public/index.html', page_title: nil, show_nav: false)
   begin
     html = File.open('templates/index.html.erb').read
     template = ERB.new(html, trim_mode: '-')
@@ -840,9 +840,8 @@ begin
   render_manifest
 
   regional = regional_urls
-  main_nav = regional.any? ? [['Main firehose', './'], ['Regional & Fire', 'regional.html']] : nil
   render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary, weather_alerts,
-              nav_links: main_nav)
+              show_nav: regional.any?)
 
   if regional.any?
     puts "Rendering regional page for #{regional.size} feeds..."
@@ -850,7 +849,7 @@ begin
     render_html(regional_feeds, nil, {}, [], nil, [],
                 output_path: 'public/regional.html',
                 page_title: "#{title} · Regional & Fire",
-                nav_links: [['Main firehose', './'], ['Regional & Fire', 'regional.html']])
+                show_nav: true)
   end
 
   puts "Successfully rendered HTML and manifest files."

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -9,14 +9,21 @@
   <link rel="apple-touch-icon" href="img/icon.png">
   <link type="text/css" rel="stylesheet" href="main.css"/>
   <link rel="manifest" href="./manifest.json">
-  <title><%= title %></title>
+  <title><%= html_escape(page_title || title) %></title>
   <meta name="description" content="<%= description %>"/>
 </head>
 <body>
 <main class="container">
   <header class="site-header">
-    <h1 class="site-title" aria-label="Page Title"><%= title %></h1>
+    <h1 class="site-title" aria-label="Page Title"><%= html_escape(page_title || title) %></h1>
     <p class="site-meta" aria-label="Last updated">Updated <%= Time.now.strftime('%F %R %Z') -%></p>
+    <% if nav_links && !nav_links.empty? %>
+    <nav class="page-nav" aria-label="Site sections">
+      <% nav_links.each do |label, href| -%>
+        <a href="<%= html_escape(href) %>"><%= html_escape(label) %></a>
+      <% end -%>
+    </nav>
+    <% end %>
     <ul class="stat-chips" aria-label="Feed statistics">
       <li class="chip"><strong><%= feeds.size %></strong> <%= feeds.size == 1 ? 'feed' : 'feeds' %></li>
       <li class="chip"><strong><%= feeds.sum { |_url, parsed| parsed.items.count } %></strong> stories</li>

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -17,11 +17,10 @@
   <header class="site-header">
     <h1 class="site-title" aria-label="Page Title"><%= html_escape(page_title || title) %></h1>
     <p class="site-meta" aria-label="Last updated">Updated <%= Time.now.strftime('%F %R %Z') -%></p>
-    <% if nav_links && !nav_links.empty? %>
+    <% if show_nav %>
     <nav class="page-nav" aria-label="Site sections">
-      <% nav_links.each do |label, href| -%>
-        <a href="<%= html_escape(href) %>"><%= html_escape(label) %></a>
-      <% end -%>
+      <a href="./">Main firehose</a>
+      <a href="regional.html">Regional &amp; Fire</a>
     </nav>
     <% end %>
     <ul class="stat-chips" aria-label="Feed statistics">

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -628,7 +628,7 @@ class RenderTest < Minitest::Test
     render_html({ 'http://x/feed' => feed }, nil, {}, [], nil, [],
                 output_path: out,
                 page_title: 'News Firehose · Regional & Fire',
-                nav_links: [['Main firehose', './'], ['Regional & Fire', 'regional.html']])
+                show_nav: true)
     html = File.read(out)
     assert_includes html, '<title>News Firehose · Regional &amp; Fire</title>',
                      "secondary page must use the page_title override"

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -595,6 +595,51 @@ class RenderTest < Minitest::Test
            "with no live source and no cache anywhere, feed() must use the offline placeholder"
   end
 
+  # --- Regional / secondary page --------------------------------------------
+
+  def test_regional_urls_empty_without_flag_is_hermetic
+    saved = ENV.values_at('RSS_REGIONAL_URLS', 'RENDER_REGIONAL')
+    ENV.delete('RSS_REGIONAL_URLS')
+    ENV.delete('RENDER_REGIONAL')
+    assert_empty regional_urls,
+                 "regional feeds must be off by default so the test suite makes no extra fetches"
+  ensure
+    ENV['RSS_REGIONAL_URLS'], ENV['RENDER_REGIONAL'] = saved
+  end
+
+  def test_regional_urls_from_env_parses_and_validates
+    saved = ENV['RSS_REGIONAL_URLS']
+    ENV['RSS_REGIONAL_URLS'] = 'https://a.example/feed/, not-a-url ,https://b.example/feed/'
+    assert_equal ['https://a.example/feed/', 'https://b.example/feed/'], regional_urls,
+                 "regional_urls must split, trim, drop empties, and keep only http(s) URLs"
+  ensure
+    saved ? ENV['RSS_REGIONAL_URLS'] = saved : ENV.delete('RSS_REGIONAL_URLS')
+  end
+
+  def test_render_html_writes_secondary_page_with_title_and_nav
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>Sierra Sun</title><link>http://x</link>
+      <description>d</description>
+      <item><title>Tahoe headline</title><link>http://x/1</link></item>
+      </channel></rss>
+    XML
+    out = 'public/regional_test_output.html'
+    render_html({ 'http://x/feed' => feed }, nil, {}, [], nil, [],
+                output_path: out,
+                page_title: 'News Firehose · Regional & Fire',
+                nav_links: [['Main firehose', './'], ['Regional & Fire', 'regional.html']])
+    html = File.read(out)
+    assert_includes html, '<title>News Firehose · Regional &amp; Fire</title>',
+                     "secondary page must use the page_title override"
+    assert_includes html, 'class="page-nav"', "secondary page must render the inter-page nav"
+    assert_includes html, 'href="regional.html"', "nav must link to the regional page"
+    assert_includes html, 'Tahoe headline', "secondary page must render its feed items"
+    refute_includes html, 'Feed Summary', "regional page is lightweight: no per-feed AI summary box"
+  ensure
+    File.delete(out) if out && File.exist?(out)
+  end
+
   def test_summarize_news_skips_offline_feed_returning_nil
     # Must short-circuit before any AI call, so this needs no network/token.
     offline = create_offline_feed('http://example.com/down')

--- a/urls-regional.txt
+++ b/urls-regional.txt
@@ -1,0 +1,5 @@
+https://sierranevadaally.org/feed/
+https://www.moonshineink.com/feed/
+https://www.sierrasun.com/feed/
+https://www.tahoedailytribune.com/feed/
+https://inciweb.wildfire.gov/incidents/rss.xml


### PR DESCRIPTION
## What
Adds an optional **Regional & Fire** secondary page (`public/regional.html`) linked from the main page, per the earlier request to surface high-signal Truckee/Tahoe + fire sources without bloating the lean main firehose.

**Feeds** (all runner-verified — return `200` + valid RSS from the Actions runner):
- Sierra Nevada Ally
- Moonshine Ink
- Sierra Sun (`/feed/`)
- Tahoe Daily Tribune (`/feed/`)
- InciWeb (active fire incidents)

Deliberately excludes The Union / GV Wire / Cal Fire's own page — those datacenter-IP-block the runner (`429/403`).

## Design — DRY, lightweight, hermetic
- **Reuses the same ERB template + CSS.** `render_html` gains `output_path:` / `page_title:` / `nav_links:` kwargs; defaults keep the main page output **byte-identical**. A small `.page-nav` links both pages.
- **No per-feed AI on the regional page** → zero extra AI cost. It reuses the existing feed **cache + fallback + friendly-name** pipeline, so cards show clean channel titles automatically.
- **Off by default** so the test suite stays hermetic/fast: `regional_urls` is empty unless `RSS_REGIONAL_URLS` is set or `RENDER_REGIONAL=1` selects `urls-regional.txt`. The deploy workflow sets `RENDER_REGIONAL=1`; the whole `public/` dir already deploys, so `regional.html` ships automatically (no build-step change).
- **Bonus fix:** page `<title>`/`<h1>` are now HTML-escaped (were raw) — no change for the default title, correct for titles containing `&`.

## Tests
+3 tests: `regional_urls` env parsing, hermetic-off default, secondary-page render (nav + escaped title + feed items, no AI box). Full suite **52 runs / 181 assertions / 0 failures** in `ruby:4-alpine`. Verified a live two-page render: `regional.html` (28 KB) shows all 5 friendly names; both pages carry the nav. Generated `regional.html` is gitignored like `index.html`.
