### PR TITLE
feat: regional AI overview, InciWeb CA/NV filter, Moonshine on main

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -33,6 +33,18 @@ FEED_FALLBACKS = {
   ]
 }.freeze
 
+# Optional per-feed item filters: keep only items for which the lambda returns
+# true. InciWeb's RSS is national; we keep just California/Nevada incidents so
+# the regional Fire section stays on-topic. Item titles are prefixed with the
+# 2-letter state code (e.g. "CACNP …" / "NVELD …") and the description carries
+# "State: California".
+FEED_ITEM_FILTERS = {
+  'https://inciweb.wildfire.gov/incidents/rss.xml' => lambda do |item|
+    "#{item.title}".match?(/\A(?:CA|NV)/) ||
+      "#{item.description}".match?(/State:\s*(?:California|Nevada)/)
+  end
+}.freeze
+
 # Channel title stamped on the placeholder feed built for an offline/failed
 # source (see create_offline_feed). Callers use feed_offline? to detect it.
 FEED_OFFLINE_TITLE = 'Feed currently offline'
@@ -347,7 +359,7 @@ def fetch_feeds(urls)
 
   results = parallel_map(urls) do |url|
     begin
-      feed(url)
+      apply_item_filter(url, feed(url))
     rescue StandardError => e
       puts "Unexpected error fetching '#{url}': #{e.message}"
       create_offline_feed(url)
@@ -360,6 +372,20 @@ def fetch_feeds(urls)
     value = results[url]
     ordered[url] = value unless value.nil?
   end
+end
+
+# Apply any configured FEED_ITEM_FILTERS to a parsed feed in place, dropping the
+# items the filter rejects. No-op for feeds without a filter or without items,
+# so it's safe to call on every fetched feed.
+def apply_item_filter(url, parsed)
+  filter = FEED_ITEM_FILTERS[url]
+  return parsed unless filter && parsed.respond_to?(:items) && parsed.items
+
+  parsed.items.delete_if { |item| !filter.call(item) }
+  parsed
+rescue StandardError => e
+  puts "Warning: item filter failed for '#{url}': #{e.message}"
+  parsed
 end
 
 # HTML escape function to prevent XSS attacks
@@ -714,7 +740,7 @@ end
 # overall summary is stored under `summary` for backward compatibility with
 # older single-summary cache files. Only called when the overall summary is
 # usable (see caller), so a fresh cache never persists an error placeholder.
-def cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
+def cache_summaries(overall_summary, feed_summaries, breaking_news_summary, regional_summary = nil)
   return unless overall_summary && !overall_summary.empty?
 
   begin
@@ -724,7 +750,8 @@ def cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
         timestamp: Time.now.utc.iso8601,
         summary: overall_summary,
         feed_summaries: feed_summaries || {},
-        breaking_news_summary: breaking_news_summary
+        breaking_news_summary: breaking_news_summary,
+        regional_summary: regional_summary
       }.to_json)
     end
     puts "Summaries cached successfully"
@@ -733,10 +760,19 @@ def cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
   end
 end
 
+# True when an AI summary is genuine content, not an empty / placeholder / error
+# string. Lets callers hide the summary box (and skip caching) instead of
+# surfacing "No content available…" or an "unavailable"/"failed" error.
+def usable_summary?(summary)
+  summary && !summary.empty? &&
+    !PLACEHOLDER_SUMMARIES.include?(summary) &&
+    !summary.include?('unavailable') && !summary.include?('failed')
+end
+
 # Load the cached summary bundle if present and still within the 6h TTL.
-# Returns { 'overall' =>, 'feeds' =>, 'breaking' => } or nil on miss/expiry/
-# error. Older single-summary cache files (just `summary`) still load — the
-# per-feed and breaking parts are simply treated as empty.
+# Returns { 'overall' =>, 'feeds' =>, 'breaking' =>, 'regional' => } or nil on
+# miss/expiry/error. Older cache files (missing newer keys) still load — the
+# absent parts are simply treated as empty.
 def load_cached_summaries
   # Skip cache if force regeneration is requested
   if ENV['FORCE_REGENERATE'] == 'true'
@@ -756,7 +792,8 @@ def load_cached_summaries
       {
         'overall' => data['summary'],
         'feeds' => data['feed_summaries'] || {},
-        'breaking' => data['breaking_news_summary']
+        'breaking' => data['breaking_news_summary'],
+        'regional' => data['regional_summary']
       }
     else
       puts "Cached summary expired, will generate new one"
@@ -786,6 +823,8 @@ puts "Analytics UA: #{ENV['ANALYTICS_UA'] ? 'configured' : 'not configured'}"
 puts ""
 
 feeds = fetch_feeds(rss_urls)
+regional = regional_urls
+regional_feeds = regional.any? ? fetch_feeds(regional) : {}
 breaking_news = fetch_yubanet_breaking_news
 weather_alerts = fetch_weather_alerts
 cached = load_cached_summaries
@@ -797,23 +836,26 @@ if cached
   overall_summary = cached['overall']
   feed_summaries = cached['feeds'] || {}
   breaking_news_summary = cached['breaking']
+  regional_summary = cached['regional']
   puts "Using cached summaries."
 else
   puts "Generating summaries for #{feeds.size} feeds..."
 
   # Every summary is an independent GitHub Models request, so pipeline them all
-  # (per-feed + overall + breaking) across the bounded pool instead of making
-  # N+2 serial calls. On a 3-feed run this is 5 HTTP round-trips collapsed from
-  # sequential to roughly one call's wall-clock.
+  # (per-feed + overall + breaking + regional overview) across the bounded pool
+  # instead of making N+ serial calls. On a 3-feed run this collapses several
+  # HTTP round-trips from sequential to roughly one call's wall-clock.
   jobs = feeds.keys.map { |url| [:feed, url] }
   jobs << [:overall, nil]
   jobs << [:breaking, nil]
+  jobs << [:regional, nil] if regional_feeds.any?
 
   summaries = parallel_map(jobs) do |(kind, url)|
     case kind
     when :feed     then summarize_news(feeds[url])
     when :overall  then summarize_overall_news(feeds.values)
     when :breaking then summarize_breaking_news(breaking_news)
+    when :regional then summarize_overall_news(regional_feeds.values)
     end
   end
 
@@ -822,12 +864,12 @@ else
   end
   overall_summary = summaries[[:overall, nil]]
   breaking_news_summary = summaries[[:breaking, nil]]
+  regional_summary = regional_feeds.any? ? summaries[[:regional, nil]] : nil
 
   # Only cache if we actually got a useful overall summary, so neither an error
   # placeholder nor a degraded "no content" render gets persisted for the TTL.
-  if overall_summary && !PLACEHOLDER_SUMMARIES.include?(overall_summary) &&
-     !overall_summary.include?("unavailable") && !overall_summary.include?("failed")
-    cache_summaries(overall_summary, feed_summaries, breaking_news_summary)
+  if usable_summary?(overall_summary)
+    cache_summaries(overall_summary, feed_summaries, breaking_news_summary, regional_summary)
     puts "Generated and cached new summaries."
   else
     puts "Generated summaries but not caching due to errors."
@@ -839,14 +881,12 @@ puts "Overall Summary: #{overall_summary}"
 begin
   render_manifest
 
-  regional = regional_urls
   render_html(feeds, overall_summary, feed_summaries, breaking_news, breaking_news_summary, weather_alerts,
               show_nav: regional.any?)
 
   if regional.any?
     puts "Rendering regional page for #{regional.size} feeds..."
-    regional_feeds = fetch_feeds(regional)
-    render_html(regional_feeds, nil, {}, [], nil, [],
+    render_html(regional_feeds, (regional_summary if usable_summary?(regional_summary)), {}, [], nil, [],
                 output_path: 'public/regional.html',
                 page_title: "#{title} · Regional & Fire",
                 show_nav: true)

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -640,6 +640,53 @@ class RenderTest < Minitest::Test
     File.delete(out) if out && File.exist?(out)
   end
 
+  def test_apply_item_filter_keeps_only_regional_inciweb_items
+    inciweb = 'https://inciweb.wildfire.gov/incidents/rss.xml'
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>InciWeb</title><link>http://x</link><description>d</description>
+      <item><title>CACNP Santa Rosa Island Fire</title><link>http://x/1</link><description>State: California</description></item>
+      <item><title>NVELD Grapevine</title><link>http://x/2</link><description>State: Nevada</description></item>
+      <item><title>AZCOF Pocket Fire</title><link>http://x/3</link><description>State: Arizona</description></item>
+      <item><title>UTMLF Babylon Fire</title><link>http://x/4</link><description>State: Utah</description></item>
+      </channel></rss>
+    XML
+    apply_item_filter(inciweb, feed)
+    titles = feed.items.map { |i| i.title.to_s }
+    assert_equal ['CACNP Santa Rosa Island Fire', 'NVELD Grapevine'], titles,
+                 "InciWeb filter must keep only California/Nevada incidents"
+  end
+
+  def test_apply_item_filter_is_noop_for_unfiltered_feed
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>C</title><link>http://x</link><description>d</description>
+      <item><title>AZ thing</title><link>http://x/1</link></item></channel></rss>
+    XML
+    apply_item_filter('http://example.com/no-filter', feed)
+    assert_equal 1, feed.items.size, "feeds without a configured filter must pass through untouched"
+  end
+
+  def test_usable_summary_detects_placeholders_and_errors
+    assert usable_summary?('The county approved a new budget.'), "real prose is usable"
+    refute usable_summary?(nil), "nil is not usable"
+    refute usable_summary?(''), "empty string is not usable"
+    refute usable_summary?('No content available for summarization.'), "placeholder is not usable"
+    refute usable_summary?('AI summary unavailable at this time'), "an unavailable error is not usable"
+    refute usable_summary?('Request failed'), "a failed error is not usable"
+  end
+
+  def test_summary_cache_roundtrips_regional_overview
+    FileUtils.rm_f('cache/ai_summary_cache.json')
+    cache_summaries('OVERALL', { 'u' => 'PERFEED' }, 'BREAKING', 'REGIONAL_OVERVIEW')
+    loaded = load_cached_summaries
+    assert_equal 'REGIONAL_OVERVIEW', loaded['regional'],
+                 "the regional overview must round-trip through the summary cache bundle"
+    assert_equal 'OVERALL', loaded['overall'], "existing keys must still round-trip"
+  ensure
+    FileUtils.rm_f('cache/ai_summary_cache.json')
+  end
+
   def test_summarize_news_skips_offline_feed_returning_nil
     # Must short-circuit before any AI call, so this needs no network/token.
     offline = create_offline_feed('http://example.com/down')

--- a/urls-regional.txt
+++ b/urls-regional.txt
@@ -1,5 +1,4 @@
 https://sierranevadaally.org/feed/
-https://www.moonshineink.com/feed/
 https://www.sierrasun.com/feed/
 https://www.tahoedailytribune.com/feed/
 https://inciweb.wildfire.gov/incidents/rss.xml

--- a/urls.txt
+++ b/urls.txt
@@ -1,3 +1,4 @@
 https://yubanet.com/feed/
 https://www.theunion.com/search/?f=rss&t=article&c=news
 https://www.mynevadacounty.com/RSSFeed.aspx?ModID=1&CID=All-newsflash.xml
+https://www.moonshineink.com/feed/


### PR DESCRIPTION
Rounds out the Regional & Fire secondary page and main-page curation. All lightweight, cache-first, no new per-run AI cost.

## Changes
- **InciWeb -> CA/NV only.** FEED_ITEM_FILTERS + apply_item_filter trim the national wildfire feed from ~50 incidents to the ~6 relevant to California/Nevada (matched on the 2-letter state prefix in the title, e.g. CACNP/NVELD, or "State: California|Nevada" in the description). Applied at fetch_feeds time so the card, stat-chip count, and AI summary all see the trimmed set.
- **Regional AI overview (cached).** A :regional job is pipelined into the existing summary batch and stored in the same cache bundle (regional_summary field), so a cache hit still makes zero extra AI calls. Rendered only when it is a real summary.
- **usable_summary? helper.** Centralizes the "genuine content vs placeholder/error" check; both the cache gate and the regional box reuse it (box hidden on nil/placeholder/error).
- **Moonshine Ink -> main page**, removed from regional so no feed appears on both pages.

## Validation
- Docker ruby:4-alpine: `ruby -c` clean; full suite 56 runs / 191 assertions / 0 failures.
- Live RENDER_REGIONAL=1 render: InciWeb shows exactly 6 items (2 CA + 4 NV), zero other states; Moonshine renders on main; regional page renders (overview box hidden without a token, as designed - production has one).

New tests: apply_item_filter CA/NV keep + no-op-without-filter, usable_summary? detection, regional overview cache round-trip.
