### PR TITLE
Run RSS summaries locally with LFM2.5

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,7 +125,7 @@ export ANALYTICS_UA="UA-XXXXX-Y"
 
 # Optional local AI summaries
 export AI_API_ENDPOINT="http://127.0.0.1:8080/v1/chat/completions"
-export AI_MODEL="lfm2.5-1.2b-instruct"
+export AI_MODEL="lfm2.5-2.6b"
 ```
 
 ### CI/CD Pipeline (.github/workflows/)
@@ -175,7 +175,7 @@ export AI_MODEL="lfm2.5-1.2b-instruct"
 - Application gracefully handles network failures with placeholder content
 
 ### AI Summary Limitations
-- Requires a local llama.cpp server loaded with LFM2.5-1.2B-Instruct
+- Requires a local llama.cpp server loaded with LFM2.5-2.6B
 - Falls back to "AI summarization unavailable" without token
 - Summaries cached for 6 hours to minimize API usage
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,7 +88,7 @@ After making changes, ALWAYS perform these validation steps:
 - **Basic rendering**: Verify HTML generation with default feeds
 - **Error handling**: Test with invalid/offline RSS URLs (should show "Feed offline" placeholders)
 - **Backup feeds**: Test fallback when primary feeds are empty/invalid
-- **AI summaries**: Test with/without GITHUB_TOKEN (graceful degradation)
+- **AI summaries**: Test with/without a local llama.cpp endpoint (graceful degradation)
 - **Environment customization**: Test with custom RSS_TITLE, RSS_DESCRIPTION, RSS_URLS
 
 ## Repository Structure
@@ -123,8 +123,9 @@ export RSS_TITLE="My News"
 export RSS_DESCRIPTION="My really awesome news aggregation page"
 export ANALYTICS_UA="UA-XXXXX-Y"
 
-# Optional AI summaries (requires GitHub token)
-export GITHUB_TOKEN="your_github_token_for_ai_summaries"
+# Optional local AI summaries
+export AI_API_ENDPOINT="http://127.0.0.1:8080/v1/chat/completions"
+export AI_MODEL="lfm2.5-1.2b-instruct"
 ```
 
 ### CI/CD Pipeline (.github/workflows/)
@@ -158,7 +159,7 @@ export GITHUB_TOKEN="your_github_token_for_ai_summaries"
 
 ### Performance Considerations
 - Render script fetches RSS feeds in real-time (~3 seconds total)
-- AI summaries cached for 6 hours (if GITHUB_TOKEN provided)
+- AI summaries cached for 6 hours (when the local model endpoint is available)
 - Docker builds include Ruby gem installation (~2+ minutes)
 
 ## Known Issues and Workarounds
@@ -174,7 +175,7 @@ export GITHUB_TOKEN="your_github_token_for_ai_summaries"
 - Application gracefully handles network failures with placeholder content
 
 ### AI Summary Limitations
-- Requires GitHub personal access token
+- Requires a local llama.cpp server loaded with LFM2.5-1.2B-Instruct
 - Falls back to "AI summarization unavailable" without token
 - Summaries cached for 6 hours to minimize API usage
 
@@ -182,7 +183,7 @@ export GITHUB_TOKEN="your_github_token_for_ai_summaries"
 These error messages are expected and handled gracefully:
 ```
 General error with feed 'https://example.com/feed': Failed to open TCP connection
-No GITHUB_TOKEN provided, skipping AI summarization
+No local AI endpoint configured, skipping AI summarization
 WARNING: fetching https://dl-cdn.alpinelinux.org/alpine: Permission denied (Docker build)
 ```
 

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -49,6 +49,40 @@ jobs:
         restore-keys: |
           ai-summary-
 
+    - name: Restore local AI runtime
+      id: cache-local-ai
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .local-ai
+        key: local-ai-llama-b10298-lfm2.5-1.2b-q4km-76022b8
+
+    - name: Install local AI runtime
+      if: steps.cache-local-ai.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p .local-ai/llama .local-ai/models
+
+        curl -fsSL \
+          https://github.com/ggml-org/llama.cpp/releases/download/b10298/llama-b10298-bin-ubuntu-x64.tar.gz \
+          -o "$RUNNER_TEMP/llama.tar.gz"
+        echo "c8c7a1e7ff36c92eac16440e224b82afbee9caef843a9aa84ba1e5a9f0329af4  $RUNNER_TEMP/llama.tar.gz" |
+          sha256sum --check
+        tar -xzf "$RUNNER_TEMP/llama.tar.gz" -C .local-ai/llama --strip-components=1
+
+        curl -fsSL \
+          https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/76022b8bfa64af5862d6bce90a676c3cc9b17b52/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
+          -o .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf
+        echo "b1b3de114215d9507409a662a501a631095a479a419584e8a2ded6304b19b4f5  .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf" |
+          sha256sum --check
+
+    - name: Save local AI runtime
+      if: steps.cache-local-ai.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .local-ai
+        key: local-ai-llama-b10298-lfm2.5-1.2b-q4km-76022b8
+
     # Sets up Ruby environment
     - name: Setup Ruby
       uses: ruby/setup-ruby@8e41b362d2589a22a44c1cfa214b3c83052c195b # v1.318.0
@@ -57,9 +91,37 @@ jobs:
         bundler-cache: true
         
     # Runs the Ruby script to render the page
-    - run: bundle exec ruby render.rb
+    - name: Render with local LFM2.5 summaries
+      shell: bash
+      run: |
+        set -euo pipefail
+        .local-ai/llama/llama-server \
+          --model .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
+          --alias lfm2.5-1.2b-instruct \
+          --host 127.0.0.1 \
+          --port 8080 \
+          --ctx-size 4096 \
+          --parallel 2 \
+          --threads 4 \
+          --no-webui \
+          > "$RUNNER_TEMP/llama-server.log" 2>&1 &
+        server_pid=$!
+        trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
+
+        for _ in {1..60}; do
+          curl -fsS http://127.0.0.1:8080/health >/dev/null && break
+          sleep 2
+        done
+        if ! curl -fsS http://127.0.0.1:8080/health >/dev/null; then
+          cat "$RUNNER_TEMP/llama-server.log"
+          exit 1
+        fi
+
+        bundle exec ruby render.rb
       env:
-        GITHUB_TOKEN: ${{ secrets.API_TOKEN }}
+        AI_API_ENDPOINT: http://127.0.0.1:8080/v1/chat/completions
+        AI_MODEL: lfm2.5-1.2b-instruct
+        FEED_CONCURRENCY: '2'
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}
         RENDER_REGIONAL: '1' # Also build public/regional.html from urls-regional.txt
 

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -18,11 +18,11 @@ on:
       ai_model:
         description: 'Local model used for summaries'
         required: false
-        default: 'lfm2.5-1.2b'
+        default: 'lfm2.5-2.6b'
         type: choice
         options:
-          - 'lfm2.5-1.2b'
           - 'lfm2.5-2.6b'
+          - 'lfm2.5-1.2b'
   push:  # Triggers the workflow on push events to the main branch
     branches: [ main ]
   schedule:  # Triggers the workflow on a schedule (twice a day)
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .local-ai
-        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}-v1
+        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}-v1
 
     - name: Install local AI runtime
       if: steps.cache-local-ai.outputs.cache-hit != 'true'
@@ -97,14 +97,14 @@ jobs:
         curl -fsSL "$model_url" -o "$model_file"
         echo "$model_sha  $model_file" | sha256sum --check
       env:
-        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
+        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}
 
     - name: Save local AI runtime
       if: steps.cache-local-ai.outputs.cache-hit != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .local-ai
-        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}-v1
+        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}-v1
 
     # Sets up Ruby environment
     - name: Setup Ruby
@@ -157,8 +157,8 @@ jobs:
         bundle exec ruby render.rb
       env:
         AI_API_ENDPOINT: http://127.0.0.1:8080/v1/chat/completions
-        AI_MODEL: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
-        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
+        AI_MODEL: ${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}
+        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}
         AI_REQUEST_TIMEOUT: '240'
         FEED_CONCURRENCY: '2'
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -15,6 +15,14 @@ on:
         options:
           - 'false'
           - 'true'
+      ai_model:
+        description: 'Local model used for summaries'
+        required: false
+        default: 'lfm2.5-1.2b'
+        type: choice
+        options:
+          - 'lfm2.5-1.2b'
+          - 'lfm2.5-2.6b'
   push:  # Triggers the workflow on push events to the main branch
     branches: [ main ]
   schedule:  # Triggers the workflow on a schedule (twice a day)
@@ -54,7 +62,7 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .local-ai
-        key: local-ai-llama-b10298-lfm2.5-1.2b-q4km-76022b8
+        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}-v1
 
     - name: Install local AI runtime
       if: steps.cache-local-ai.outputs.cache-hit != 'true'
@@ -70,18 +78,33 @@ jobs:
           sha256sum --check
         tar -xzf "$RUNNER_TEMP/llama.tar.gz" -C .local-ai/llama --strip-components=1
 
-        curl -fsSL \
-          https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/76022b8bfa64af5862d6bce90a676c3cc9b17b52/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
-          -o .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf
-        echo "b1b3de114215d9507409a662a501a631095a479a419584e8a2ded6304b19b4f5  .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf" |
-          sha256sum --check
+        case "${AI_MODEL_VARIANT}" in
+          lfm2.5-1.2b)
+            model_url="https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/76022b8bfa64af5862d6bce90a676c3cc9b17b52/LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
+            model_file=".local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
+            model_sha="b1b3de114215d9507409a662a501a631095a479a419584e8a2ded6304b19b4f5"
+            ;;
+          lfm2.5-2.6b)
+            model_url="https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/resolve/b421ad1d549afeda6a0fb2ad3a697cb5a7879adc/LFM2.5-2.6B-Q4_K_M.gguf"
+            model_file=".local-ai/models/LFM2.5-2.6B-Q4_K_M.gguf"
+            model_sha="79fdf00351b46cf26f020aead28d01889886be87c55fa0eb907e6f9b00bfee14"
+            ;;
+          *)
+            echo "Unsupported AI model: ${AI_MODEL_VARIANT}" >&2
+            exit 1
+            ;;
+        esac
+        curl -fsSL "$model_url" -o "$model_file"
+        echo "$model_sha  $model_file" | sha256sum --check
+      env:
+        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
 
     - name: Save local AI runtime
       if: steps.cache-local-ai.outputs.cache-hit != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .local-ai
-        key: local-ai-llama-b10298-lfm2.5-1.2b-q4km-76022b8
+        key: local-ai-llama-b10298-${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}-v1
 
     # Sets up Ruby environment
     - name: Setup Ruby
@@ -95,9 +118,21 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
+        case "${AI_MODEL_VARIANT}" in
+          lfm2.5-1.2b)
+            model_file=".local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
+            ;;
+          lfm2.5-2.6b)
+            model_file=".local-ai/models/LFM2.5-2.6B-Q4_K_M.gguf"
+            ;;
+          *)
+            echo "Unsupported AI model: ${AI_MODEL_VARIANT}" >&2
+            exit 1
+            ;;
+        esac
         .local-ai/llama/llama-server \
-          --model .local-ai/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf \
-          --alias lfm2.5-1.2b-instruct \
+          --model "$model_file" \
+          --alias "$AI_MODEL_VARIANT" \
           --host 127.0.0.1 \
           --port 8080 \
           --ctx-size 4096 \
@@ -108,7 +143,7 @@ jobs:
         server_pid=$!
         trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
 
-        for _ in {1..60}; do
+        for _ in {1..90}; do
           curl -fsS http://127.0.0.1:8080/health >/dev/null && break
           sleep 2
         done
@@ -120,7 +155,8 @@ jobs:
         bundle exec ruby render.rb
       env:
         AI_API_ENDPOINT: http://127.0.0.1:8080/v1/chat/completions
-        AI_MODEL: lfm2.5-1.2b-instruct
+        AI_MODEL: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
+        AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
         FEED_CONCURRENCY: '2'
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}
         RENDER_REGIONAL: '1' # Also build public/regional.html from urls-regional.txt

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -138,6 +138,8 @@ jobs:
           --ctx-size 4096 \
           --parallel 2 \
           --threads 4 \
+          --reasoning off \
+          --reasoning-budget 0 \
           --no-webui \
           > "$RUNNER_TEMP/llama-server.log" 2>&1 &
         server_pid=$!

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -157,6 +157,7 @@ jobs:
         AI_API_ENDPOINT: http://127.0.0.1:8080/v1/chat/completions
         AI_MODEL: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
         AI_MODEL_VARIANT: ${{ github.event.inputs.ai_model || 'lfm2.5-1.2b' }}
+        AI_REQUEST_TIMEOUT: '240'
         FEED_CONCURRENCY: '2'
         FORCE_REGENERATE: ${{ github.event.inputs.force_regenerate || 'false' }}
         RENDER_REGIONAL: '1' # Also build public/regional.html from urls-regional.txt

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build-iPhoneSimulator/
 /public/index.html
 /public/regional.html
 /cache/
+/.local-ai/

--- a/README.md
+++ b/README.md
@@ -64,17 +64,20 @@ Available environment variable options:
 "RSS_BACKUP_URLS=https://backup1/feed,http://backup2/rss"
 "RSS_TITLE=My News"
 "RSS_DESCRIPTION=My really awesome news aggregation page"
-"GITHUB_TOKEN=your_github_token_for_ai_summaries"
+"AI_API_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions" # Local llama.cpp server
+"AI_MODEL=lfm2.5-1.2b-instruct"
 "FORCE_REGENERATE=true" # Skip cache and force full regeneration
 ```
 
 ### AI-Powered Summaries
 
-RSS Firehose can generate AI-powered summaries of your news feeds using GitHub's Models service. To enable this feature:
+RSS Firehose generates AI summaries locally with Liquid AI's LFM2.5-1.2B-Instruct model and llama.cpp. The GitHub Pages workflow downloads pinned, checksum-verified builds of both, caches them, and performs inference on the GitHub Actions runner.
 
-1. Set the `GITHUB_TOKEN` environment variable with your GitHub personal access token
-2. Summaries are cached for 6 hours to minimize API usage
-3. If no token is provided, the app gracefully falls back to displaying feeds without summaries
+No API key, hosted inference account, or per-request fee is required. The quantized model is approximately 731 MB and is cached between workflow runs. Generated summaries remain cached for 6 hours.
+
+For local development, start a llama.cpp server with the model alias `lfm2.5-1.2b-instruct`, then set `AI_API_ENDPOINT` as shown above. Without a local endpoint, rendering continues normally with summaries disabled.
+
+LFM2.5 is distributed under the [LFM Open License v1.0](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/blob/main/LICENSE).
 
 #### Forcing Full Regeneration
 
@@ -116,7 +119,7 @@ This dual approach ensures varied and interesting content rather than repetitive
 
 - **Robust Error Handling**: Feeds that are offline or unreachable are gracefully handled with placeholder content
 - **Smart Backup Feeds**: Configure backup RSS feeds that are used when primary feeds are empty
-- **AI Summarization**: Optional AI-powered news summaries using GitHub Models
+- **AI Summarization**: Optional AI-powered news summaries using an OpenAI-compatible API
 - **Caching**: Intelligent caching of AI summaries to reduce API usage
 - **Input Validation**: Automatic validation of RSS URLs and configuration
 - **Responsive Design**: Mobile-friendly HTML output with accessibility features

--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ Available environment variable options:
 "RSS_TITLE=My News"
 "RSS_DESCRIPTION=My really awesome news aggregation page"
 "AI_API_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions" # Local llama.cpp server
-"AI_MODEL=lfm2.5-1.2b-instruct"
+"AI_MODEL=lfm2.5-2.6b"
 "FORCE_REGENERATE=true" # Skip cache and force full regeneration
 ```
 
 ### AI-Powered Summaries
 
-RSS Firehose generates AI summaries locally with Liquid AI's LFM2.5-1.2B-Instruct model and llama.cpp. The GitHub Pages workflow downloads pinned, checksum-verified builds of both, caches them, and performs inference on the GitHub Actions runner.
+RSS Firehose generates AI summaries locally with Liquid AI's LFM2.5-2.6B model and llama.cpp. The GitHub Pages workflow downloads pinned, checksum-verified builds of both, caches them, and performs inference on the GitHub Actions runner.
 
-No API key, hosted inference account, or per-request fee is required. The quantized model is approximately 731 MB and is cached between workflow runs. Generated summaries remain cached for 6 hours.
+No API key, hosted inference account, or per-request fee is required. The default quantized model is approximately 1.67 GB and is cached between workflow runs. Generated summaries remain cached for 6 hours.
 
-Manual workflow dispatches can select `lfm2.5-2.6b` for quality comparisons. Its Q4_K_M model is approximately 1.67 GB; scheduled runs continue using the smaller 1.2B model unless the workflow default is changed.
+Manual workflow dispatches can select `lfm2.5-1.2b` as a faster, lower-quality fallback.
 
-For local development, start a llama.cpp server with the model alias `lfm2.5-1.2b-instruct`, then set `AI_API_ENDPOINT` as shown above. Without a local endpoint, rendering continues normally with summaries disabled.
+For local development, start a llama.cpp server with the model alias `lfm2.5-2.6b`, then set `AI_API_ENDPOINT` as shown above. Without a local endpoint, rendering continues normally with summaries disabled.
 
-LFM2.5 is distributed under the [LFM Open License v1.0](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/blob/main/LICENSE).
+LFM2.5 is distributed under the [LFM Open License v1.0](https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/blob/main/LICENSE).
 
 #### Forcing Full Regeneration
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ RSS Firehose generates AI summaries locally with Liquid AI's LFM2.5-1.2B-Instruc
 
 No API key, hosted inference account, or per-request fee is required. The quantized model is approximately 731 MB and is cached between workflow runs. Generated summaries remain cached for 6 hours.
 
+Manual workflow dispatches can select `lfm2.5-2.6b` for quality comparisons. Its Q4_K_M model is approximately 1.67 GB; scheduled runs continue using the smaller 1.2B model unless the workflow default is changed.
+
 For local development, start a llama.cpp server with the model alias `lfm2.5-1.2b-instruct`, then set `AI_API_ENDPOINT` as shown above. Without a local endpoint, rendering continues normally with summaries disabled.
 
 LFM2.5 is distributed under the [LFM Open License v1.0](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/blob/main/LICENSE).

--- a/render.rb
+++ b/render.rb
@@ -64,8 +64,8 @@ PLACEHOLDER_SUMMARIES = [
 ].freeze
 
 # Shared newsroom contract for all summaries. These rules are intentionally
-# explicit because the local 1.2B model needs stronger grounding than a large
-# hosted model.
+# explicit because small local models need stronger grounding than large hosted
+# models.
 SUMMARY_PROMPT_GUARDRAILS = <<~PROMPT.strip.freeze
   Use only facts stated in the supplied items. Do not invent, infer, or connect separate items.
   Each bracketed ITEM is independent unless its own text explicitly says otherwise.
@@ -539,7 +539,11 @@ def convert_markdown_links_to_html(text)
   end
 end
 
-AI_SUMMARY_MODEL = 'lfm2.5-1.2b-instruct'
+AI_SUMMARY_MODEL = 'lfm2.5-2.6b'
+
+def configured_ai_model
+  ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
+end
 
 # Enforce the one-paragraph plain-text output contract before HTML rendering.
 # The prefix cleanup is a deterministic backstop for common small-model
@@ -597,7 +601,7 @@ def generate_ai_summary(system_prompt, user_content, context:, temperature:, max
         { "role": "system", "content": system_prompt },
         { "role": "user", "content": user_content }
       ],
-      "model": ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL),
+      "model": configured_ai_model,
       "temperature": temperature,
       "max_tokens": max_tokens,
       "top_p": top_p
@@ -881,6 +885,7 @@ def cache_summaries(overall_summary, feed_summaries, breaking_news_summary, regi
     File.open(CACHE_FILE, 'w') do |f|
       f.write({
         timestamp: Time.now.utc.iso8601,
+        model: configured_ai_model,
         summary: overall_summary,
         feed_summaries: feed_summaries || {},
         breaking_news_summary: breaking_news_summary,
@@ -918,6 +923,10 @@ def load_cached_summaries
   begin
     data = JSON.parse(File.read(CACHE_FILE))
     timestamp = Time.parse(data['timestamp'])
+    if !ENV['AI_API_ENDPOINT'].to_s.strip.empty? && data['model'] != configured_ai_model
+      puts "Cached summaries use #{data['model'] || 'an unknown model'}, regenerating with #{configured_ai_model}"
+      return nil
+    end
 
     # Check if cache is still valid (6 hours)
     if Time.now.utc - timestamp < 6 * 60 * 60
@@ -951,8 +960,7 @@ puts "Title: #{title}"
 puts "Description: #{description}"
 puts "RSS URLs: #{rss_urls.join(', ')}" if rss_urls.any?
 puts "Backup URLs: #{rss_backup_urls.join(', ')}" if rss_backup_urls.any?
-configured_model = ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
-puts "Local AI: #{ENV['AI_API_ENDPOINT'].to_s.strip.empty? ? 'not configured (summaries disabled)' : configured_model}"
+puts "Local AI: #{ENV['AI_API_ENDPOINT'].to_s.strip.empty? ? 'not configured (summaries disabled)' : configured_ai_model}"
 puts "Analytics UA: #{ENV['ANALYTICS_UA'] ? 'configured' : 'not configured'}"
 puts ""
 

--- a/render.rb
+++ b/render.rb
@@ -544,7 +544,25 @@ AI_SUMMARY_MODEL = 'lfm2.5-1.2b-instruct'
 # Enforce the one-paragraph plain-text output contract before HTML rendering.
 # The prefix cleanup is a deterministic backstop for common small-model
 # preambles that the prompt explicitly forbids.
-def format_summary(text)
+def truncate_summary_sentences(text, max_words)
+  return text if max_words.nil? || text.split.size <= max_words
+
+  sentences = text.scan(/.*?(?:[.!?](?=\s|\z)|\z)/).map(&:strip).reject(&:empty?)
+  selected = []
+  word_count = 0
+  sentences.each do |sentence|
+    sentence_words = sentence.split.size
+    break if word_count + sentence_words > max_words
+
+    selected << sentence
+    word_count += sentence_words
+  end
+  return selected.join(' ') unless selected.empty?
+
+  "#{text.split.first(max_words).join(' ').sub(/[,:;]\z/, '')}."
+end
+
+def format_summary(text, max_words: nil)
   summary = text.to_s.gsub(/\s+/, ' ').strip
   summary = summary.sub(/\A(?:summary:\s*)/i, '')
   summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
@@ -555,12 +573,13 @@ def format_summary(text)
   summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
   summary = summary.sub(/\A\#{1,6}\s*/, '')
   summary = summary.sub(/\A([a-z])/) { Regexp.last_match(1).upcase }
+  summary = truncate_summary_sentences(summary, max_words)
   html_escape(summary.strip)
 end
 
 # Request a chat completion from the local llama.cpp server started by the
 # Pages workflow. No API key or hosted inference service is required.
-def generate_ai_summary(system_prompt, user_content, context:, temperature:, max_tokens:, top_p:)
+def generate_ai_summary(system_prompt, user_content, context:, temperature:, max_tokens:, top_p:, max_words:)
   endpoint = ENV['AI_API_ENDPOINT'].to_s.strip
   if endpoint.empty?
     puts "No local AI endpoint configured, skipping AI summarization"
@@ -595,7 +614,7 @@ def generate_ai_summary(system_prompt, user_content, context:, temperature:, max
   if content.to_s.strip.empty?
     "Summary generation failed - no valid response from AI service."
   else
-    format_summary(content)
+    format_summary(content, max_words: max_words)
   end
 rescue HTTParty::Error => e
   puts "HTTP error summarizing #{context}: #{e.message}"
@@ -625,8 +644,9 @@ def summarize_news(feed)
     news_content,
     context: "news",
     temperature: 0.2,
-    max_tokens: 180,
-    top_p: 0.9
+    max_tokens: 300,
+    top_p: 0.9,
+    max_words: 120
   )
 end
 
@@ -645,8 +665,9 @@ def summarize_overall_news(feeds)
     all_content,
     context: "overall news",
     temperature: 0.2,
-    max_tokens: 220,
-    top_p: 0.9
+    max_tokens: 360,
+    top_p: 0.9,
+    max_words: 150
   )
 end
 

--- a/render.rb
+++ b/render.rb
@@ -63,31 +63,39 @@ PLACEHOLDER_SUMMARIES = [
   'No articles available for summarization.'
 ].freeze
 
-# Shared guardrails for all summaries. Keep them terse and explicit so the
-# model stays grounded in the supplied feed text and returns plain prose only.
-SUMMARY_PROMPT_GUARDRAILS = 'Use only the supplied text. Do not invent details, mention the feed/source, or add bullets, headings, HTML, markdown, or preamble. Return one plain paragraph.'.freeze
+# Shared newsroom contract for all summaries. These rules are intentionally
+# explicit because the local 1.2B model needs stronger grounding than a large
+# hosted model.
+SUMMARY_PROMPT_GUARDRAILS = <<~PROMPT.strip.freeze
+  Use only facts stated in the supplied items. Do not invent, infer, or connect separate items.
+  Preserve names, places, dates, numbers, and operational status verbs exactly as written.
+  Treat jokes, asides, rhetorical questions, and parenthetical comments as non-factual and omit them.
+  Do not mention the feed, source, article, supplied text, or that you are summarizing.
+  Never begin with "The text", "This article", "These stories", "The following", or "In summary".
+  Do not end with a general sentence about what the stories reflect, highlight, or demonstrate.
+  Return exactly one plain-text paragraph with no label, markdown, HTML, headings, bullets, links, or line breaks.
+PROMPT
 
 NEWS_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
-  You are writing a concise local-news digest for a homepage.
-  Summarize the most newsworthy items in under 120 words.
-  Lead with the most important item, then merge related developments.
-  Keep names, places, dates, and numbers only when they are present in the source text.
-  If the material is thin or repetitive, stay conservative rather than speculating.
+  Write a local-news digest of at most 120 words.
+  Open with the most recent or consequential development, then briefly include only closely related or important items.
+  Use direct declarative sentences and active voice. If the items are thin or repetitive, write less rather than padding.
   #{SUMMARY_PROMPT_GUARDRAILS}
 PROMPT
 
 OVERALL_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
-  You are editing the site's overall front-page digest across multiple local sources.
-  In under 160 words, synthesize the most important stories and themes across the provided text.
-  Prefer concrete facts, impacts, and comparisons.
-  If the sources are sparse, say only what they clearly support.
+  Write a front-page local-news digest of at most 150 words.
+  Lead with the most consequential development, then summarize other important developments in descending importance.
+  State concrete facts and clearly stated local impacts. Do not merge unrelated items into a single claim or invent a theme.
+  Use direct declarative sentences and active voice. If coverage is sparse, write less rather than padding.
   #{SUMMARY_PROMPT_GUARDRAILS}
 PROMPT
 
 BREAKING_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
-  You are editing a breaking-news strip for a homepage.
-  In under 80 words, lead with the newest or most urgent development.
-  State the immediate impact or current status when present, and keep the wording terse and factual.
+  Write a breaking-news update of at most 70 words.
+  Lead with the newest or most urgent event and its current status.
+  Keep status verbs exactly as written; for example, never change "releasing" to "deploying".
+  Include a time only when it appears in the supplied item. Use terse, direct declarative sentences.
   #{SUMMARY_PROMPT_GUARDRAILS}
 PROMPT
 
@@ -101,6 +109,9 @@ FEED_NAME_MAX = 40
 # token-bounded content window, so several items still fit and the AI gets
 # breadth as well as depth.
 ITEM_DESC_MAX = 240
+SUMMARY_ITEMS_PER_FEED = 10
+OVERALL_ITEMS_PER_FEED = 5
+BREAKING_SUMMARY_ITEMS = 10
 
 # National Weather Service active-alerts API + the zone to watch. CAC057 is
 # Nevada County, CA (covers Nevada City, Grass Valley and Truckee); override
@@ -521,14 +532,17 @@ end
 
 AI_SUMMARY_MODEL = 'lfm2.5-1.2b-instruct'
 
-# Apply the shared markdown-ish -> HTML formatting used by every summary:
-# escape raw HTML first, then allow a tiny safe subset: newlines, "## x",
-# markdown links, and **bold**.
+# Enforce the one-paragraph plain-text output contract before HTML rendering.
+# The prefix cleanup is a deterministic backstop for common small-model
+# preambles that the prompt explicitly forbids.
 def format_summary(text)
-  summary = html_escape(text.to_s).gsub("\n", "<br/>")
-  summary = summary.gsub(/(##\s*)(.*)/) { "<h2>#{html_escape($2)}</h2>" }
-  summary = convert_markdown_links_to_html(summary)
-  summary.gsub(/\*\*(.*?)\*\*/) { "<b>#{html_escape($1)}</b>" }
+  summary = text.to_s.gsub(/\s+/, ' ').strip
+  summary = summary.sub(/\A(?:summary:\s*)/i, '')
+  summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
+  summary = summary.gsub(/\[([^\]]{1,100})\]\([^)[:space:]]{1,200}\)/, '\1')
+  summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
+  summary = summary.sub(/\A\#{1,6}\s*/, '')
+  html_escape(summary.strip)
 end
 
 # Request a chat completion from the local llama.cpp server started by the
@@ -584,20 +598,21 @@ def summarize_news(feed)
   # an AI refusal ("I'm unable to access external websites") to visitors.
   return nil if feed_offline?(feed)
 
-  news_content = if feed.is_a?(Array)
-                   feed.flat_map { |f| extract_feed_content(f) }.join('. ')
-                 else
-                   extract_feed_content(feed).join('. ')
-                 end
+  lines = if feed.is_a?(Array)
+            feed.flat_map { |f| extract_feed_content(f) }
+          else
+            extract_feed_content(feed)
+          end
+  news_content = bounded_summary_content(deduplicate_summary_lines(lines), 4096)
   return "No articles available for summarization." if news_content.empty?
 
   generate_ai_summary(
     NEWS_SUMMARY_PROMPT,
-    news_content[0..4096],
+    news_content,
     context: "news",
-    temperature: 0.5,
-    max_tokens: 300,
-    top_p: 1
+    temperature: 0.2,
+    max_tokens: 180,
+    top_p: 0.9
   )
 end
 
@@ -607,34 +622,82 @@ def summarize_overall_news(feeds)
   # Skip offline placeholders so the bare feed URL never pollutes the
   # front-page summary (or makes the model refuse to summarize it).
   live_feeds = feeds.reject { |feed| feed_offline?(feed) }
-  all_content = live_feeds.flat_map { |feed| extract_feed_content(feed) }.join('. ')
+  all_lines = live_feeds.flat_map { |feed| extract_feed_content(feed, limit: OVERALL_ITEMS_PER_FEED) }
+  all_content = bounded_summary_content(deduplicate_summary_lines(all_lines), 6144)
   return "No articles available for summarization." if all_content.empty?
 
   generate_ai_summary(
     OVERALL_SUMMARY_PROMPT,
-    all_content[0..6144],
+    all_content,
     context: "overall news",
-    temperature: 0.4,
-    max_tokens: 400,
-    top_p: 0.95
+    temperature: 0.2,
+    max_tokens: 220,
+    top_p: 0.9
   )
 end
 
-# Extract content from a feed for summarization: one "Title - description" line
-# per item. Includes the article description (real substance) and deliberately
-# omits the raw URL, which only wastes tokens and tempts the model to "comment
-# on" or "access" the source. Handles offline feeds gracefully.
-def extract_feed_content(feed)
+# Normalize an item timestamp across RSS and Atom dialects.
+def item_published_at(item)
+  raw = if item.respond_to?(:date) && item.date
+          item.date
+        elsif item.respond_to?(:pubDate) && item.pubDate
+          item.pubDate
+        elsif item.respond_to?(:published) && item.published
+          item.published
+        elsif item.respond_to?(:updated) && item.updated
+          item.updated
+        end
+  raw = raw.content if raw.respond_to?(:content)
+  raw.is_a?(Time) ? raw : Time.parse(raw.to_s)
+rescue ArgumentError, TypeError
+  nil
+end
+
+# Extract recent items as "Title - description" lines. Dated entries are sorted
+# newest first; undated entries retain feed order. URLs are deliberately omitted.
+def extract_feed_content(feed, limit: SUMMARY_ITEMS_PER_FEED)
   return [] if feed.nil? || !feed.respond_to?(:items) || feed.items.nil?
 
-  feed.items.map do |item|
+  sorted_items = feed.items.each_with_index.sort_by do |item, index|
+    published_at = item_published_at(item)
+    published_at ? [0, -published_at.to_f, index] : [1, 0, index]
+  end.map(&:first)
+
+  sorted_items.filter_map do |item|
     title = item_title(item).to_s.strip
     desc = item_description(item)
-    desc.empty? ? title : "#{title} - #{desc}"
-  end.reject(&:empty?)
+    text = desc.empty? ? title : "#{title} - #{desc}"
+    text unless text.empty?
+  end.first(limit)
 rescue => e
   puts "Error extracting feed content: #{e.message}"
   []
+end
+
+# Join only complete item lines within a character budget so model input never
+# ends with a truncated headline or sentence fragment.
+def bounded_summary_content(lines, max_chars)
+  selected = []
+  length = 0
+  lines.each do |line|
+    added_length = line.length + (selected.empty? ? 0 : 2)
+    break if length + added_length > max_chars
+
+    selected << line
+    length += added_length
+  end
+  selected.join('. ')
+end
+
+def deduplicate_summary_lines(lines)
+  seen = {}
+  lines.each_with_object([]) do |line, unique|
+    title = line.split(' - ', 2).first.to_s.downcase.gsub(/\s+/, ' ').strip
+    next if title.empty? || seen[title]
+
+    seen[title] = true
+    unique << line
+  end
 end
 
 # Parse YubaNet "Happening Now" HTML into breaking-news entries. Pure (no I/O)
@@ -692,16 +755,17 @@ end
 def summarize_breaking_news(breaking_news)
   return "No breaking news available for summarization." if breaking_news.nil? || breaking_news.empty?
 
-  latest_entries = breaking_news.first(5)
-  content_text = latest_entries.map { |entry| "#{entry[:timestamp]}: #{entry[:content]}" }.join('. ')
+  latest_entries = breaking_news.first(BREAKING_SUMMARY_ITEMS)
+  lines = latest_entries.map { |entry| "#{entry[:timestamp]}: #{entry[:content]}" }
+  content_text = bounded_summary_content(lines, 3072)
   return "No breaking news content available for summarization." if content_text.empty?
 
   generate_ai_summary(
     BREAKING_SUMMARY_PROMPT,
-    content_text[0..3072],
+    content_text,
     context: "breaking news",
-    temperature: 0.3,
-    max_tokens: 200,
+    temperature: 0.1,
+    max_tokens: 110,
     top_p: 0.9
   )
 end

--- a/render.rb
+++ b/render.rb
@@ -572,6 +572,7 @@ def generate_ai_summary(system_prompt, user_content, context:, temperature:, max
   response = HTTParty.post(
     endpoint,
     headers: headers,
+    timeout: (ENV['AI_REQUEST_TIMEOUT'] || '180').to_i,
     body: {
       "messages": [
         { "role": "system", "content": system_prompt },

--- a/render.rb
+++ b/render.rb
@@ -70,14 +70,17 @@ SUMMARY_PROMPT_GUARDRAILS = <<~PROMPT.strip.freeze
   Use only facts stated in the supplied items. Do not invent, infer, or connect separate items.
   Preserve names, places, dates, numbers, and operational status verbs exactly as written.
   Treat jokes, asides, rhetorical questions, and parenthetical comments as non-factual and omit them.
+  Do not add severity, importance, or promotional adjectives unless they appear in the supplied item.
   Do not mention the feed, source, article, supplied text, or that you are summarizing.
   Never begin with "The text", "This article", "These stories", "The following", or "In summary".
   Do not end with a general sentence about what the stories reflect, highlight, or demonstrate.
+  Avoid filler such as "recent updates", "meanwhile", "additionally", "highlights", "showcases", "shines", or "makes headlines".
   Return exactly one plain-text paragraph with no label, markdown, HTML, headings, bullets, links, or line breaks.
 PROMPT
 
 NEWS_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
   Write a local-news digest of at most 120 words.
+  The first sentence must report a specific event with a named subject and action, not announce that updates or stories exist.
   Open with the most recent or consequential development, then briefly include only closely related or important items.
   Use direct declarative sentences and active voice. If the items are thin or repetitive, write less rather than padding.
   #{SUMMARY_PROMPT_GUARDRAILS}
@@ -85,6 +88,7 @@ PROMPT
 
 OVERALL_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
   Write a front-page local-news digest of at most 150 words.
+  The first sentence must report a specific event with a named subject and action, not announce a digest or list of updates.
   Lead with the most consequential development, then summarize other important developments in descending importance.
   State concrete facts and clearly stated local impacts. Do not merge unrelated items into a single claim or invent a theme.
   Use direct declarative sentences and active voice. If coverage is sparse, write less rather than padding.
@@ -93,7 +97,9 @@ PROMPT
 
 BREAKING_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
   Write a breaking-news update of at most 70 words.
-  Lead with the newest or most urgent event and its current status.
+  The first sentence must summarize the item labeled LATEST UPDATE.
+  Do not describe an earlier incident as active when a newer item says crews are mopping up, canceling units, or releasing resources.
+  Do not add severity words such as "major" unless the latest item uses them.
   Keep status verbs exactly as written; for example, never change "releasing" to "deploying".
   Include a time only when it appears in the supplied item. Use terse, direct declarative sentences.
   #{SUMMARY_PROMPT_GUARDRAILS}
@@ -111,7 +117,7 @@ FEED_NAME_MAX = 40
 ITEM_DESC_MAX = 240
 SUMMARY_ITEMS_PER_FEED = 10
 OVERALL_ITEMS_PER_FEED = 5
-BREAKING_SUMMARY_ITEMS = 10
+BREAKING_SUMMARY_ITEMS = 5
 
 # National Weather Service active-alerts API + the zone to watch. CAC057 is
 # Nevada County, CA (covers Nevada City, Grass Valley and Truckee); override
@@ -539,6 +545,8 @@ def format_summary(text)
   summary = text.to_s.gsub(/\s+/, ' ').strip
   summary = summary.sub(/\A(?:summary:\s*)/i, '')
   summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
+  summary = summary.sub(/\Arecent updates (?:highlight|include)\s+/i, '')
+  summary = summary.sub(/\A[^.:]{1,80}\bis seeing several key updates:\s*/i, '')
   summary = summary.gsub(/\[([^\]]{1,100})\]\([^)[:space:]]{1,200}\)/, '\1')
   summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
   summary = summary.sub(/\A\#{1,6}\s*/, '')
@@ -700,6 +708,15 @@ def deduplicate_summary_lines(lines)
   end
 end
 
+def breaking_summary_content(breaking_news)
+  entries = breaking_news.first(BREAKING_SUMMARY_ITEMS)
+  lines = entries.each_with_index.map do |entry, index|
+    label = index.zero? ? 'LATEST UPDATE' : 'EARLIER UPDATE'
+    "#{label} — #{entry[:timestamp]}: #{entry[:content]}"
+  end
+  bounded_summary_content(lines, 3072)
+end
+
 # Parse YubaNet "Happening Now" HTML into breaking-news entries. Pure (no I/O)
 # so it can be unit-tested against fixture HTML without hitting the network.
 #
@@ -755,9 +772,7 @@ end
 def summarize_breaking_news(breaking_news)
   return "No breaking news available for summarization." if breaking_news.nil? || breaking_news.empty?
 
-  latest_entries = breaking_news.first(BREAKING_SUMMARY_ITEMS)
-  lines = latest_entries.map { |entry| "#{entry[:timestamp]}: #{entry[:content]}" }
-  content_text = bounded_summary_content(lines, 3072)
+  content_text = breaking_summary_content(breaking_news)
   return "No breaking news content available for summarization." if content_text.empty?
 
   generate_ai_summary(

--- a/render.rb
+++ b/render.rb
@@ -548,10 +548,29 @@ end
 # Enforce the one-paragraph plain-text output contract before HTML rendering.
 # The prefix cleanup is a deterministic backstop for common small-model
 # preambles that the prompt explicitly forbids.
+def split_summary_sentences(text)
+  chars = text.each_char.to_a
+  sentences = []
+  start_index = 0
+
+  chars.each_index do |index|
+    next unless ['.', '!', '?'].include?(chars[index])
+    next unless index == chars.length - 1 || chars[index + 1].strip.empty?
+
+    sentence = chars[start_index..index].join.strip
+    sentences << sentence unless sentence.empty?
+    start_index = index + 1
+  end
+
+  tail = chars[start_index..]&.join.to_s.strip
+  sentences << tail unless tail.empty?
+  sentences
+end
+
 def truncate_summary_sentences(text, max_words)
   return text if max_words.nil? || text.split.size <= max_words
 
-  sentences = text.scan(/.*?(?:[.!?](?=\s|\z)|\z)/).map(&:strip).reject(&:empty?)
+  sentences = split_summary_sentences(text)
   selected = []
   word_count = 0
   sentences.each do |sentence|
@@ -566,13 +585,40 @@ def truncate_summary_sentences(text, max_words)
   "#{text.split.first(max_words).join(' ').sub(/[,:;]\z/, '')}."
 end
 
+def strip_generic_summary_closer(summary)
+  sentences = split_summary_sentences(summary)
+  return summary if sentences.length < 2
+
+  closer = sentences.last.downcase
+  generic_starts = [
+    'these developments reflect',
+    'these developments highlight',
+    'these developments show',
+    'these developments demonstrate',
+    'these stories reflect',
+    'these stories highlight',
+    'these stories show',
+    'these stories demonstrate',
+    'these updates reflect',
+    'these updates highlight',
+    'these updates show',
+    'these updates demonstrate',
+    'those developments reflect',
+    'those stories reflect',
+    'those updates reflect'
+  ]
+  return summary unless generic_starts.any? { |prefix| closer.start_with?(prefix) }
+
+  sentences[0...-1].join(' ')
+end
+
 def format_summary(text, max_words: nil)
-  summary = text.to_s.gsub(/\s+/, ' ').strip
+  summary = text.to_s.split.join(' ')
   summary = summary.sub(/\A(?:summary:\s*)/i, '')
   summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
   summary = summary.sub(/\Arecent updates (?:highlight|include)\s+/i, '')
   summary = summary.sub(/\A[^.:]{1,80}\bis seeing several key updates:\s*/i, '')
-  summary = summary.sub(/\s+(?:These|Those) (?:developments|stories|updates) (?:reflect|highlight|show|demonstrate)[^.]*\.\z/i, '')
+  summary = strip_generic_summary_closer(summary)
   summary = summary.gsub(/\[([^\]]{1,100})\]\([^)[:space:]]{1,200}\)/, '\1')
   summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
   summary = summary.sub(/\A\#{1,6}\s*/, '')

--- a/render.rb
+++ b/render.rb
@@ -550,9 +550,11 @@ def format_summary(text)
   summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
   summary = summary.sub(/\Arecent updates (?:highlight|include)\s+/i, '')
   summary = summary.sub(/\A[^.:]{1,80}\bis seeing several key updates:\s*/i, '')
+  summary = summary.sub(/\s+(?:These|Those) (?:developments|stories|updates) (?:reflect|highlight|show|demonstrate)[^.]*\.\z/i, '')
   summary = summary.gsub(/\[([^\]]{1,100})\]\([^)[:space:]]{1,200}\)/, '\1')
   summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
   summary = summary.sub(/\A\#{1,6}\s*/, '')
+  summary = summary.sub(/\A([a-z])/) { Regexp.last_match(1).upcase }
   html_escape(summary.strip)
 end
 
@@ -775,21 +777,12 @@ rescue => e
   []
 end
 
-# Summarize breaking news content using AI
+# Breaking updates remain verbatim. The local 1.2B model repeatedly changed
+# operational status and merged unrelated incidents, which is unacceptable on
+# the site's most time-sensitive surface.
 def summarize_breaking_news(breaking_news)
   return "No breaking news available for summarization." if breaking_news.nil? || breaking_news.empty?
-
-  content_text = breaking_summary_content(breaking_news)
-  return "No breaking news content available for summarization." if content_text.empty?
-
-  generate_ai_summary(
-    BREAKING_SUMMARY_PROMPT,
-    content_text,
-    context: "breaking news",
-    temperature: 0.1,
-    max_tokens: 110,
-    top_p: 0.9
-  )
+  nil
 end
 
 # Turn an NWS active-alerts API JSON body into a compact, escaped-later list of

--- a/render.rb
+++ b/render.rb
@@ -63,6 +63,34 @@ PLACEHOLDER_SUMMARIES = [
   'No articles available for summarization.'
 ].freeze
 
+# Shared guardrails for all summaries. Keep them terse and explicit so the
+# model stays grounded in the supplied feed text and returns plain prose only.
+SUMMARY_PROMPT_GUARDRAILS = 'Use only the supplied text. Do not invent details, mention the feed/source, or add bullets, headings, HTML, markdown, or preamble. Return one plain paragraph.'.freeze
+
+NEWS_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
+  You are writing a concise local-news digest for a homepage.
+  Summarize the most newsworthy items in under 120 words.
+  Lead with the most important item, then merge related developments.
+  Keep names, places, dates, and numbers only when they are present in the source text.
+  If the material is thin or repetitive, stay conservative rather than speculating.
+  #{SUMMARY_PROMPT_GUARDRAILS}
+PROMPT
+
+OVERALL_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
+  You are editing the site's overall front-page digest across multiple local sources.
+  In under 160 words, synthesize the most important stories and themes across the provided text.
+  Prefer concrete facts, impacts, and comparisons.
+  If the sources are sparse, say only what they clearly support.
+  #{SUMMARY_PROMPT_GUARDRAILS}
+PROMPT
+
+BREAKING_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
+  You are editing a breaking-news strip for a homepage.
+  In under 80 words, lead with the newest or most urgent development.
+  State the immediate impact or current status when present, and keep the wording terse and factual.
+  #{SUMMARY_PROMPT_GUARDRAILS}
+PROMPT
+
 # Maximum length of a friendly feed name before it is truncated with an
 # ellipsis (see feed_display_name), so a long channel title can't dominate the
 # layout or reintroduce horizontal overflow on narrow screens.
@@ -491,51 +519,55 @@ def convert_markdown_links_to_html(text)
   end
 end
 
-# Shared GitHub Models endpoint/model used for all AI summaries.
-AI_SUMMARY_ENDPOINT = "https://models.inference.ai.azure.com/chat/completions"
-AI_SUMMARY_MODEL = "gpt-4o-mini"
+AI_SUMMARY_MODEL = 'lfm2.5-1.2b-instruct'
 
 # Apply the shared markdown-ish -> HTML formatting used by every summary:
-# newlines to <br/>, "## x" to escaped <h2>, markdown links, and **bold**.
+# escape raw HTML first, then allow a tiny safe subset: newlines, "## x",
+# markdown links, and **bold**.
 def format_summary(text)
-  summary = text.gsub("\n", "<br/>")
+  summary = html_escape(text.to_s).gsub("\n", "<br/>")
   summary = summary.gsub(/(##\s*)(.*)/) { "<h2>#{html_escape($2)}</h2>" }
   summary = convert_markdown_links_to_html(summary)
   summary.gsub(/\*\*(.*?)\*\*/) { "<b>#{html_escape($1)}</b>" }
 end
 
-# Request a GitHub Models chat completion for a summary. Centralizes the token
-# guard, HTTP call, response parsing/formatting and error handling shared by
-# every summarize_* method. `context` only affects log wording.
+# Request a chat completion from the local llama.cpp server started by the
+# Pages workflow. No API key or hosted inference service is required.
 def generate_ai_summary(system_prompt, user_content, context:, temperature:, max_tokens:, top_p:)
-  unless ENV['GITHUB_TOKEN']
-    puts "No GITHUB_TOKEN provided, skipping AI summarization"
-    return "AI summarization unavailable - no API token configured."
+  endpoint = ENV['AI_API_ENDPOINT'].to_s.strip
+  if endpoint.empty?
+    puts "No local AI endpoint configured, skipping AI summarization"
+    return "AI summarization unavailable - local model not configured."
   end
 
+  headers = { "Content-Type" => "application/json" }
+
   response = HTTParty.post(
-    AI_SUMMARY_ENDPOINT,
-    headers: {
-      "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{ENV['GITHUB_TOKEN']}"
-    },
+    endpoint,
+    headers: headers,
     body: {
       "messages": [
         { "role": "system", "content": system_prompt },
         { "role": "user", "content": user_content }
       ],
-      "model": AI_SUMMARY_MODEL,
+      "model": ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL),
       "temperature": temperature,
       "max_tokens": max_tokens,
       "top_p": top_p
     }.to_json
   )
+  unless response.success?
+    puts "AI service returned HTTP #{response.code} while summarizing #{context}"
+    return "Summary generation failed - AI service returned HTTP #{response.code}."
+  end
+
   parsed_response = sanitize_response(response.body)
 
-  if parsed_response && parsed_response["choices"] && !parsed_response["choices"].empty?
-    format_summary(parsed_response["choices"].first["message"]["content"])
-  else
+  content = parsed_response&.dig("choices", 0, "message", "content")
+  if content.to_s.strip.empty?
     "Summary generation failed - no valid response from AI service."
+  else
+    format_summary(content)
   end
 rescue HTTParty::Error => e
   puts "HTTP error summarizing #{context}: #{e.message}"
@@ -560,7 +592,7 @@ def summarize_news(feed)
   return "No articles available for summarization." if news_content.empty?
 
   generate_ai_summary(
-    "You are a news editor writing a front-page digest. Summarize the key stories below in under 150 words of clear, factual journalistic prose. Lead with the most important developments and include specific names, places, dates, and figures when present. Do not mention the feed or that you are summarizing. Output only the summary text: no headings, labels, lists, or preamble.",
+    NEWS_SUMMARY_PROMPT,
     news_content[0..4096],
     context: "news",
     temperature: 0.5,
@@ -579,7 +611,7 @@ def summarize_overall_news(feeds)
   return "No articles available for summarization." if all_content.empty?
 
   generate_ai_summary(
-    "You are the editor of a major newspaper writing the front-page summary across all of today's sources. In under 200 words, synthesize the most important stories, common themes, and significant trends. Explain what happened, who is affected, and why it matters, emphasizing facts and implications over a list of events. Do not mention the feeds or sources themselves. Output only the summary text: no headings, labels, or preamble.",
+    OVERALL_SUMMARY_PROMPT,
     all_content[0..6144],
     context: "overall news",
     temperature: 0.4,
@@ -665,7 +697,7 @@ def summarize_breaking_news(breaking_news)
   return "No breaking news content available for summarization." if content_text.empty?
 
   generate_ai_summary(
-    "You are a breaking-news editor. In under 100 words, summarize the most critical, time-sensitive developments below. Highlight what readers need to know right now, including immediate impacts and any emerging pattern. Use urgent but clear language. Output only the summary text: no headings, labels, or preamble.",
+    BREAKING_SUMMARY_PROMPT,
     content_text[0..3072],
     context: "breaking news",
     temperature: 0.3,
@@ -818,7 +850,7 @@ puts "Title: #{title}"
 puts "Description: #{description}"
 puts "RSS URLs: #{rss_urls.join(', ')}" if rss_urls.any?
 puts "Backup URLs: #{rss_backup_urls.join(', ')}" if rss_backup_urls.any?
-puts "GitHub Token: #{ENV['GITHUB_TOKEN'] ? 'configured' : 'not configured (AI summaries disabled)'}"
+puts "Local AI: #{ENV['AI_API_ENDPOINT'].to_s.strip.empty? ? 'not configured (summaries disabled)' : AI_SUMMARY_MODEL}"
 puts "Analytics UA: #{ENV['ANALYTICS_UA'] ? 'configured' : 'not configured'}"
 puts ""
 
@@ -841,7 +873,7 @@ if cached
 else
   puts "Generating summaries for #{feeds.size} feeds..."
 
-  # Every summary is an independent GitHub Models request, so pipeline them all
+  # Every summary is an independent local inference request, so pipeline them
   # (per-feed + overall + breaking + regional overview) across the bounded pool
   # instead of making N+ serial calls. On a 3-feed run this collapses several
   # HTTP round-trips from sequential to roughly one call's wall-clock.

--- a/render.rb
+++ b/render.rb
@@ -929,7 +929,8 @@ puts "Title: #{title}"
 puts "Description: #{description}"
 puts "RSS URLs: #{rss_urls.join(', ')}" if rss_urls.any?
 puts "Backup URLs: #{rss_backup_urls.join(', ')}" if rss_backup_urls.any?
-puts "Local AI: #{ENV['AI_API_ENDPOINT'].to_s.strip.empty? ? 'not configured (summaries disabled)' : AI_SUMMARY_MODEL}"
+configured_model = ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
+puts "Local AI: #{ENV['AI_API_ENDPOINT'].to_s.strip.empty? ? 'not configured (summaries disabled)' : configured_model}"
 puts "Analytics UA: #{ENV['ANALYTICS_UA'] ? 'configured' : 'not configured'}"
 puts ""
 

--- a/render.rb
+++ b/render.rb
@@ -68,9 +68,11 @@ PLACEHOLDER_SUMMARIES = [
 # hosted model.
 SUMMARY_PROMPT_GUARDRAILS = <<~PROMPT.strip.freeze
   Use only facts stated in the supplied items. Do not invent, infer, or connect separate items.
+  Each bracketed ITEM is independent unless its own text explicitly says otherwise.
   Preserve names, places, dates, numbers, and operational status verbs exactly as written.
   Treat jokes, asides, rhetorical questions, and parenthetical comments as non-factual and omit them.
   Do not add severity, importance, or promotional adjectives unless they appear in the supplied item.
+  Do not describe what residents know, feel, expect, or face unless an item states it.
   Do not mention the feed, source, article, supplied text, or that you are summarizing.
   Never begin with "The text", "This article", "These stories", "The following", or "In summary".
   Do not end with a general sentence about what the stories reflect, highlight, or demonstrate.
@@ -98,7 +100,8 @@ PROMPT
 BREAKING_SUMMARY_PROMPT = <<~PROMPT.strip.freeze
   Write a breaking-news update of at most 70 words.
   The first sentence must summarize the item labeled LATEST UPDATE.
-  Do not describe an earlier incident as active when a newer item says crews are mopping up, canceling units, or releasing resources.
+  Use only the LATEST UPDATE; the update list below the summary covers earlier events.
+  Prefer its original nouns and verbs over paraphrasing.
   Do not add severity words such as "major" unless the latest item uses them.
   Keep status verbs exactly as written; for example, never change "releasing" to "deploying".
   Include a time only when it appears in the supplied item. Use terse, direct declarative sentences.
@@ -117,7 +120,7 @@ FEED_NAME_MAX = 40
 ITEM_DESC_MAX = 240
 SUMMARY_ITEMS_PER_FEED = 10
 OVERALL_ITEMS_PER_FEED = 5
-BREAKING_SUMMARY_ITEMS = 5
+BREAKING_SUMMARY_ITEMS = 1
 
 # National Weather Service active-alerts API + the zone to watch. CAC057 is
 # Nevada County, CA (covers Nevada City, Grass Valley and Truckee); override
@@ -611,7 +614,7 @@ def summarize_news(feed)
           else
             extract_feed_content(feed)
           end
-  news_content = bounded_summary_content(deduplicate_summary_lines(lines), 4096)
+  news_content = labeled_summary_content(deduplicate_summary_lines(lines), 4096)
   return "No articles available for summarization." if news_content.empty?
 
   generate_ai_summary(
@@ -631,7 +634,7 @@ def summarize_overall_news(feeds)
   # front-page summary (or makes the model refuse to summarize it).
   live_feeds = feeds.reject { |feed| feed_offline?(feed) }
   all_lines = live_feeds.flat_map { |feed| extract_feed_content(feed, limit: OVERALL_ITEMS_PER_FEED) }
-  all_content = bounded_summary_content(deduplicate_summary_lines(all_lines), 6144)
+  all_content = labeled_summary_content(deduplicate_summary_lines(all_lines), 6144)
   return "No articles available for summarization." if all_content.empty?
 
   generate_ai_summary(
@@ -697,6 +700,11 @@ def bounded_summary_content(lines, max_chars)
   selected.join('. ')
 end
 
+def labeled_summary_content(lines, max_chars)
+  labeled_lines = lines.each_with_index.map { |line, index| "[ITEM #{index + 1}] #{line}" }
+  bounded_summary_content(labeled_lines, max_chars)
+end
+
 def deduplicate_summary_lines(lines)
   seen = {}
   lines.each_with_object([]) do |line, unique|
@@ -710,9 +718,8 @@ end
 
 def breaking_summary_content(breaking_news)
   entries = breaking_news.first(BREAKING_SUMMARY_ITEMS)
-  lines = entries.each_with_index.map do |entry, index|
-    label = index.zero? ? 'LATEST UPDATE' : 'EARLIER UPDATE'
-    "#{label} — #{entry[:timestamp]}: #{entry[:content]}"
+  lines = entries.map do |entry|
+    "LATEST UPDATE — #{entry[:timestamp]}: #{entry[:content]}"
   end
   bounded_summary_content(lines, 3072)
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -808,6 +808,25 @@ class RenderTest < Minitest::Test
     FileUtils.rm_f('cache/ai_summary_cache.json')
   end
 
+  def test_summary_cache_is_invalidated_when_model_changes
+    FileUtils.mkdir_p('cache')
+    File.write(CACHE_FILE, {
+      timestamp: Time.now.utc.iso8601,
+      model: 'lfm2.5-1.2b',
+      summary: 'OLD MODEL SUMMARY'
+    }.to_json)
+    saved_endpoint = ENV['AI_API_ENDPOINT']
+    saved_model = ENV['AI_MODEL']
+    ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'
+    ENV['AI_MODEL'] = 'lfm2.5-2.6b'
+
+    assert_nil load_cached_summaries
+  ensure
+    saved_endpoint ? ENV['AI_API_ENDPOINT'] = saved_endpoint : ENV.delete('AI_API_ENDPOINT')
+    saved_model ? ENV['AI_MODEL'] = saved_model : ENV.delete('AI_MODEL')
+    FileUtils.rm_f(CACHE_FILE)
+  end
+
   def test_summarize_news_skips_offline_feed_returning_nil
     # Must short-circuit before any AI call, so this needs no network/token.
     offline = create_offline_feed('http://example.com/down')

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -107,21 +107,23 @@ class RenderTest < Minitest::Test
   def test_summary_prompts_include_shared_guardrails_and_distinct_modes
     load File.expand_path('../render.rb', __dir__)
 
-    assert_includes NEWS_SUMMARY_PROMPT, 'Use only the supplied text.', 'feed summary prompt must stay grounded'
-    assert_includes OVERALL_SUMMARY_PROMPT, 'multiple local sources', 'overall prompt must synthesize across feeds'
-    assert_includes BREAKING_SUMMARY_PROMPT, 'newest or most urgent development', 'breaking prompt must prioritize freshness'
+    assert_includes NEWS_SUMMARY_PROMPT, 'Use only facts stated in the supplied items.', 'feed summary prompt must stay grounded'
+    assert_includes OVERALL_SUMMARY_PROMPT, 'Do not merge unrelated items', 'overall prompt must not invent themes'
+    assert_includes BREAKING_SUMMARY_PROMPT, 'never change "releasing" to "deploying"', 'breaking prompt must preserve status'
+    assert_includes SUMMARY_PROMPT_GUARDRAILS, 'Treat jokes, asides', 'shared rules must reject non-factual asides'
     refute_equal NEWS_SUMMARY_PROMPT, OVERALL_SUMMARY_PROMPT, 'feed and overall prompts should not collapse into one generic prompt'
     refute_equal NEWS_SUMMARY_PROMPT, BREAKING_SUMMARY_PROMPT, 'feed and breaking prompts should stay distinct'
   end
 
-  def test_format_summary_escapes_html_and_keeps_safe_markup
+  def test_format_summary_enforces_plain_paragraph_contract
     load File.expand_path('../render.rb', __dir__)
 
-    formatted = format_summary("<script>alert(1)</script>\n**bold** [link](https://example.com)")
+    formatted = format_summary("The text highlights <script>alert(1)</script>\n**bold** [link](https://example.com)")
     refute_includes formatted, '<script>', 'raw HTML must never pass through summary rendering'
     assert_includes formatted, '&lt;script&gt;alert(1)&lt;/script&gt;', 'raw HTML should be escaped visibly'
-    assert_includes formatted, '<b>bold</b>', 'safe bold markdown should still render'
-    assert_includes formatted, '<a href="https://example.com">link</a>', 'safe markdown links should still render'
+    assert_includes formatted, 'bold link', 'markdown should collapse to plain text'
+    refute_includes formatted, 'The text highlights', 'forbidden model preambles should be removed'
+    refute_match(/<br|<b>|<a /, formatted, 'summary output must remain one plain paragraph')
   end
 
   def test_summarize_news_skips_ai_without_local_endpoint
@@ -347,6 +349,28 @@ class RenderTest < Minitest::Test
     assert_equal ["Headline One - Body detail one."], lines
     refute_includes lines.join(' '), "src.test",
                     "Raw feed URLs must not be sent to the summarizer"
+  end
+
+  def test_extract_feed_content_sorts_by_date_and_caps_items
+    rss = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>c</title><link>http://x</link><description>d</description>
+      <item><title>Old</title><link>http://x/old</link><pubDate>Mon, 03 Aug 2026 12:00:00 GMT</pubDate></item>
+      <item><title>Newest</title><link>http://x/new</link><pubDate>Wed, 05 Aug 2026 12:00:00 GMT</pubDate></item>
+      <item><title>Middle</title><link>http://x/mid</link><pubDate>Tue, 04 Aug 2026 12:00:00 GMT</pubDate></item>
+      </channel></rss>
+    XML
+
+    assert_equal %w[Newest Middle], extract_feed_content(rss, limit: 2)
+  end
+
+  def test_bounded_summary_content_never_truncates_an_item
+    assert_equal 'First item', bounded_summary_content(['First item', 'Second item'], 15)
+  end
+
+  def test_deduplicate_summary_lines_uses_normalized_title
+    lines = ['Council Update - First version', ' council   update - Duplicate', 'Fire Update - Current']
+    assert_equal ['Council Update - First version', 'Fire Update - Current'], deduplicate_summary_lines(lines)
   end
 
   # --- NWS critical weather-alert band -------------------------------------

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -125,6 +125,8 @@ class RenderTest < Minitest::Test
     assert_includes formatted, 'bold link', 'markdown should collapse to plain text'
     refute_includes formatted, 'The text highlights', 'forbidden model preambles should be removed'
     refute_match(/<br|<b>|<a /, formatted, 'summary output must remain one plain paragraph')
+    assert_equal 'A specific update.', format_summary('a specific update. These developments reflect progress.'),
+                 'generic closing language should not survive output cleanup'
   end
 
   def test_summarize_news_skips_ai_without_local_endpoint
@@ -387,6 +389,11 @@ class RenderTest < Minitest::Test
     assert_match(/\ALATEST UPDATE — time 0: update 0/, content)
     refute_includes content, 'update 1'
     refute_includes content, 'update 5'
+  end
+
+  def test_breaking_news_uses_verbatim_list_instead_of_ai_summary
+    entries = [{ timestamp: '5:22 PM', content: 'Air Attack 17 and tankers are launching.' }]
+    assert_nil summarize_breaking_news(entries)
   end
 
   # --- NWS critical weather-alert band -------------------------------------

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -110,6 +110,7 @@ class RenderTest < Minitest::Test
     assert_includes NEWS_SUMMARY_PROMPT, 'Use only facts stated in the supplied items.', 'feed summary prompt must stay grounded'
     assert_includes OVERALL_SUMMARY_PROMPT, 'Do not merge unrelated items', 'overall prompt must not invent themes'
     assert_includes BREAKING_SUMMARY_PROMPT, 'never change "releasing" to "deploying"', 'breaking prompt must preserve status'
+    assert_includes BREAKING_SUMMARY_PROMPT, 'LATEST UPDATE', 'breaking prompt must enforce chronological priority'
     assert_includes SUMMARY_PROMPT_GUARDRAILS, 'Treat jokes, asides', 'shared rules must reject non-factual asides'
     refute_equal NEWS_SUMMARY_PROMPT, OVERALL_SUMMARY_PROMPT, 'feed and overall prompts should not collapse into one generic prompt'
     refute_equal NEWS_SUMMARY_PROMPT, BREAKING_SUMMARY_PROMPT, 'feed and breaking prompts should stay distinct'
@@ -371,6 +372,17 @@ class RenderTest < Minitest::Test
   def test_deduplicate_summary_lines_uses_normalized_title
     lines = ['Council Update - First version', ' council   update - Duplicate', 'Fire Update - Current']
     assert_equal ['Council Update - First version', 'Fire Update - Current'], deduplicate_summary_lines(lines)
+  end
+
+  def test_breaking_summary_content_labels_latest_and_excludes_older_noise
+    entries = 6.times.map do |index|
+      { timestamp: "time #{index}", content: "update #{index}" }
+    end
+
+    content = breaking_summary_content(entries)
+    assert_match(/\ALATEST UPDATE — time 0: update 0/, content)
+    assert_includes content, 'EARLIER UPDATE — time 4: update 4'
+    refute_includes content, 'update 5'
   end
 
   # --- NWS critical weather-alert band -------------------------------------

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -378,6 +378,11 @@ class RenderTest < Minitest::Test
                  truncate_summary_sentences(text, 12)
   end
 
+  def test_split_summary_sentences_handles_punctuation_and_tail
+    assert_equal ['First sentence.', 'Second!', 'Tail without punctuation'],
+                 split_summary_sentences("First sentence. Second! Tail without punctuation")
+  end
+
   def test_labeled_summary_content_marks_items_as_independent
     assert_equal '[ITEM 1] First. [ITEM 2] Second', labeled_summary_content(%w[First Second], 100)
   end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -369,6 +369,10 @@ class RenderTest < Minitest::Test
     assert_equal 'First item', bounded_summary_content(['First item', 'Second item'], 15)
   end
 
+  def test_labeled_summary_content_marks_items_as_independent
+    assert_equal '[ITEM 1] First. [ITEM 2] Second', labeled_summary_content(%w[First Second], 100)
+  end
+
   def test_deduplicate_summary_lines_uses_normalized_title
     lines = ['Council Update - First version', ' council   update - Duplicate', 'Fire Update - Current']
     assert_equal ['Council Update - First version', 'Fire Update - Current'], deduplicate_summary_lines(lines)
@@ -381,7 +385,7 @@ class RenderTest < Minitest::Test
 
     content = breaking_summary_content(entries)
     assert_match(/\ALATEST UPDATE — time 0: update 0/, content)
-    assert_includes content, 'EARLIER UPDATE — time 4: update 4'
+    refute_includes content, 'update 1'
     refute_includes content, 'update 5'
   end
 

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -168,6 +168,7 @@ class RenderTest < Minitest::Test
 
     assert_equal 'http://127.0.0.1:8080/v1/chat/completions', request[0]
     refute_includes request[1][:headers], 'Authorization'
+    assert_equal 180, request[1][:timeout]
     body = JSON.parse(request[1][:body])
     assert_equal AI_SUMMARY_MODEL, body['model']
     assert_equal 'Content', body.dig('messages', 1, 'content')

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -101,7 +101,74 @@ class RenderTest < Minitest::Test
     assert_includes Object.private_instance_methods, :summarize_overall_news, "summarize_overall_news function should exist"
     
     puts "✓ Both summarize_news and summarize_overall_news functions are available"
-    puts "Note: Full summary variation testing requires GITHUB_TOKEN for integration validation"
+    puts "Note: Full summary variation testing requires a running local llama.cpp server"
+  end
+
+  def test_summary_prompts_include_shared_guardrails_and_distinct_modes
+    load File.expand_path('../render.rb', __dir__)
+
+    assert_includes NEWS_SUMMARY_PROMPT, 'Use only the supplied text.', 'feed summary prompt must stay grounded'
+    assert_includes OVERALL_SUMMARY_PROMPT, 'multiple local sources', 'overall prompt must synthesize across feeds'
+    assert_includes BREAKING_SUMMARY_PROMPT, 'newest or most urgent development', 'breaking prompt must prioritize freshness'
+    refute_equal NEWS_SUMMARY_PROMPT, OVERALL_SUMMARY_PROMPT, 'feed and overall prompts should not collapse into one generic prompt'
+    refute_equal NEWS_SUMMARY_PROMPT, BREAKING_SUMMARY_PROMPT, 'feed and breaking prompts should stay distinct'
+  end
+
+  def test_format_summary_escapes_html_and_keeps_safe_markup
+    load File.expand_path('../render.rb', __dir__)
+
+    formatted = format_summary("<script>alert(1)</script>\n**bold** [link](https://example.com)")
+    refute_includes formatted, '<script>', 'raw HTML must never pass through summary rendering'
+    assert_includes formatted, '&lt;script&gt;alert(1)&lt;/script&gt;', 'raw HTML should be escaped visibly'
+    assert_includes formatted, '<b>bold</b>', 'safe bold markdown should still render'
+    assert_includes formatted, '<a href="https://example.com">link</a>', 'safe markdown links should still render'
+  end
+
+  def test_summarize_news_skips_ai_without_local_endpoint
+    load File.expand_path('../render.rb', __dir__)
+    saved = ENV['AI_API_ENDPOINT']
+    ENV['AI_API_ENDPOINT'] = '   '
+    feed = RSS::Parser.parse(<<~XML, false)
+      <?xml version="1.0"?>
+      <rss version="2.0"><channel><title>c</title><link>http://x</link>
+      <description>d</description>
+      <item><title>Headline</title><link>http://x/1</link><description>Body.</description></item>
+      </channel></rss>
+    XML
+
+    assert_equal 'AI summarization unavailable - local model not configured.', summarize_news(feed)
+  ensure
+    saved ? ENV['AI_API_ENDPOINT'] = saved : ENV.delete('AI_API_ENDPOINT')
+  end
+
+  def test_generate_ai_summary_uses_local_llama_server_without_auth
+    load File.expand_path('../render.rb', __dir__)
+    saved_endpoint = ENV['AI_API_ENDPOINT']
+    ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'
+    request = nil
+    original_post = HTTParty.method(:post)
+    response = Struct.new(:body, :code) do
+      def success?
+        true
+      end
+    end.new({ choices: [{ message: { content: 'Generated summary.' } }] }.to_json, 200)
+
+    HTTParty.define_singleton_method(:post) do |url, options|
+      request = [url, options]
+      response
+    end
+    assert_equal 'Generated summary.',
+                 generate_ai_summary('System', 'Content', context: 'test', temperature: 0.2,
+                                     max_tokens: 50, top_p: 0.9)
+
+    assert_equal 'http://127.0.0.1:8080/v1/chat/completions', request[0]
+    refute_includes request[1][:headers], 'Authorization'
+    body = JSON.parse(request[1][:body])
+    assert_equal AI_SUMMARY_MODEL, body['model']
+    assert_equal 'Content', body.dig('messages', 1, 'content')
+  ensure
+    HTTParty.singleton_class.send(:define_method, :post, original_post) if original_post
+    saved_endpoint ? ENV['AI_API_ENDPOINT'] = saved_endpoint : ENV.delete('AI_API_ENDPOINT')
   end
 
   def test_force_regenerate_skips_cache

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -164,7 +164,7 @@ class RenderTest < Minitest::Test
     end
     assert_equal 'Generated summary.',
                  generate_ai_summary('System', 'Content', context: 'test', temperature: 0.2,
-                                     max_tokens: 50, top_p: 0.9)
+                                     max_tokens: 50, top_p: 0.9, max_words: 20)
 
     assert_equal 'http://127.0.0.1:8080/v1/chat/completions', request[0]
     refute_includes request[1][:headers], 'Authorization'
@@ -370,6 +370,12 @@ class RenderTest < Minitest::Test
 
   def test_bounded_summary_content_never_truncates_an_item
     assert_equal 'First item', bounded_summary_content(['First item', 'Second item'], 15)
+  end
+
+  def test_truncate_summary_sentences_respects_word_limit_without_fragments
+    text = 'First complete sentence has five words. Second sentence also has five words. Third sentence is extra.'
+    assert_equal 'First complete sentence has five words. Second sentence also has five words.',
+                 truncate_summary_sentences(text, 12)
   end
 
   def test_labeled_summary_content_marks_items_as_independent


### PR DESCRIPTION
## Summary
- replace retired GitHub Models inference with checksum-pinned llama.cpp and LFM2.5 running on the Pages runner
- use LFM2.5-2.6B by default, with 1.2B available for manual comparison
- add grounded newsroom prompts, recent-item selection, model-aware caching, and complete-sentence word limits
- keep breaking updates verbatim after testing showed small-model status drift

## Validation
- 68 tests, 235 assertions, 0 failures
- forced cold and warm workflow dispatches completed successfully
- live output: 147-word overall summary, per-feed summaries under 120 words, zero summary errors

## Workflow run
https://github.com/djdefi/rss-firehose/actions/runs/31146600145