### PR TITLE
Filter incomplete text from AI summaries

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -71,6 +71,8 @@ SUMMARY_PROMPT_GUARDRAILS = <<~PROMPT.strip.freeze
   Each bracketed ITEM is independent unless its own text explicitly says otherwise.
   Preserve names, places, dates, numbers, and operational status verbs exactly as written.
   Treat jokes, asides, rhetorical questions, and parenthetical comments as non-factual and omit them.
+  Ignore slogans, teasers, calls to action, and promotional headline fragments unless the DESCRIPTION states concrete news facts.
+  Omit incomplete or truncated text, including text ending in an ellipsis. Never complete a cut-off phrase.
   Do not add severity, importance, or promotional adjectives unless they appear in the supplied item.
   Do not describe what residents know, feel, expect, or face unless an item states it.
   Do not mention the feed, source, article, supplied text, or that you are summarizing.
@@ -465,8 +467,9 @@ end
 
 # Normalize an item's summary/description across feed dialects (RSS2
 # `description`, Atom `summary`/`content`), strip HTML tags and decode entities,
-# collapse whitespace, and cap the length. Gives the summarizer real article
-# substance (not just the headline) while keeping the content window bounded.
+# collapse whitespace, and retain only complete text within the length cap.
+# Gives the summarizer real article substance (not just the headline) while
+# keeping the content window bounded.
 # The raw value is length-capped before the tag regex runs so a pathological
 # description can't cause quadratic backtracking, and full tags (e.g. a
 # WordPress featured image tag with a long srcset) are stripped whole rather
@@ -480,7 +483,19 @@ def item_description(item)
   text = (raw.respond_to?(:content) ? raw.content.to_s : raw.to_s)[0, 4000]
   text = CGI.unescapeHTML(text.gsub(/<[^>]*>/, ' ')).gsub(/\s+/, ' ')
   text = text.gsub(/ +([.,;:!?])/, '\1').strip
-  text.length > ITEM_DESC_MAX ? "#{text[0, ITEM_DESC_MAX].rstrip}…" : text
+  return text if text.length <= ITEM_DESC_MAX && !text.end_with?('…') && !text.end_with?('...')
+
+  complete_sentences = split_summary_sentences(text).select do |sentence|
+    sentence.match?(/[.!?]\z/) && !sentence.end_with?('…') && !sentence.end_with?('...')
+  end
+  selected = []
+  complete_sentences.each do |sentence|
+    candidate = (selected + [sentence]).join(' ')
+    break if candidate.length > ITEM_DESC_MAX
+
+    selected << sentence
+  end
+  selected.join(' ')
 end
 
 # Allow only safe URL schemes in generated hrefs so a malicious feed can't inject
@@ -612,12 +627,20 @@ def strip_generic_summary_closer(summary)
   sentences[0...-1].join(' ')
 end
 
+def strip_incomplete_summary_sentences(summary)
+  sentences = split_summary_sentences(summary)
+  sentences.reject! { |sentence| sentence.include?('…') || sentence.include?('...') }
+  sentences.pop while sentences.length > 1 && !sentences.last.match?(/[.!?]\z/)
+  sentences.join(' ')
+end
+
 def format_summary(text, max_words: nil)
   summary = text.to_s.split.join(' ')
   summary = summary.sub(/\A(?:summary:\s*)/i, '')
   summary = summary.sub(/\Athe (?:supplied )?text (?:highlights|describes|reports|covers|notes|discusses)\s+/i, '')
   summary = summary.sub(/\Arecent updates (?:highlight|include)\s+/i, '')
   summary = summary.sub(/\A[^.:]{1,80}\bis seeing several key updates:\s*/i, '')
+  summary = strip_incomplete_summary_sentences(summary)
   summary = strip_generic_summary_closer(summary)
   summary = summary.gsub(/\[([^\]]{1,100})\]\([^)[:space:]]{1,200}\)/, '\1')
   summary = summary.gsub(/\*\*([^*]{1,200})\*\*/, '\1')
@@ -751,6 +774,8 @@ def extract_feed_content(feed, limit: SUMMARY_ITEMS_PER_FEED)
   sorted_items.filter_map do |item|
     title = item_title(item).to_s.strip
     desc = item_description(item)
+    next if desc.empty? && promotional_title?(title)
+
     text = desc.empty? ? title : "#{title} - #{desc}"
     text unless text.empty?
   end.first(limit)
@@ -775,8 +800,18 @@ def bounded_summary_content(lines, max_chars)
 end
 
 def labeled_summary_content(lines, max_chars)
-  labeled_lines = lines.each_with_index.map { |line, index| "[ITEM #{index + 1}] #{line}" }
+  labeled_lines = lines.each_with_index.map do |line, index|
+    title, desc = line.split(' - ', 2)
+    fields = ["[ITEM #{index + 1}] TITLE: #{title}"]
+    fields << "DESCRIPTION: #{desc}" unless desc.to_s.empty?
+    fields.join(' | ')
+  end
   bounded_summary_content(labeled_lines, max_chars)
+end
+
+def promotional_title?(title)
+  title.include?('!') &&
+    title.match?(/\b(?:apply|attend|buy|donate|join|register|subscribe|support|vote)\b/i)
 end
 
 def deduplicate_summary_lines(lines)

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -112,6 +112,8 @@ class RenderTest < Minitest::Test
     assert_includes BREAKING_SUMMARY_PROMPT, 'never change "releasing" to "deploying"', 'breaking prompt must preserve status'
     assert_includes BREAKING_SUMMARY_PROMPT, 'LATEST UPDATE', 'breaking prompt must enforce chronological priority'
     assert_includes SUMMARY_PROMPT_GUARDRAILS, 'Treat jokes, asides', 'shared rules must reject non-factual asides'
+    assert_includes SUMMARY_PROMPT_GUARDRAILS, 'Never complete a cut-off phrase',
+                    'shared rules must reject incomplete source text'
     refute_equal NEWS_SUMMARY_PROMPT, OVERALL_SUMMARY_PROMPT, 'feed and overall prompts should not collapse into one generic prompt'
     refute_equal NEWS_SUMMARY_PROMPT, BREAKING_SUMMARY_PROMPT, 'feed and breaking prompts should stay distinct'
   end
@@ -127,6 +129,9 @@ class RenderTest < Minitest::Test
     refute_match(/<br|<b>|<a /, formatted, 'summary output must remain one plain paragraph')
     assert_equal 'A specific update.', format_summary('a specific update. These developments reflect progress.'),
                  'generic closing language should not survive output cleanup'
+    assert_equal 'First complete sentence. Final complete sentence.',
+                 format_summary('First complete sentence. Cut off on We…. Final complete sentence.'),
+                 'sentences containing truncated text must be removed'
   end
 
   def test_summarize_news_skips_ai_without_local_endpoint
@@ -307,7 +312,7 @@ class RenderTest < Minitest::Test
     assert_equal "Rain & wind hit the valley.", item_description(rss.items.first)
   end
 
-  def test_item_description_truncates_overlong_text
+  def test_item_description_omits_overlong_text_without_complete_sentence
     rss = RSS::Parser.parse(<<~XML, false)
       <?xml version="1.0"?>
       <rss version="2.0"><channel><title>c</title><link>http://x</link>
@@ -316,9 +321,17 @@ class RenderTest < Minitest::Test
       <description>#{'word ' * 100}</description></item>
       </channel></rss>
     XML
-    desc = item_description(rss.items.first)
-    assert desc.length <= ITEM_DESC_MAX + 1, "Overlong descriptions must be truncated near ITEM_DESC_MAX"
-    assert desc.end_with?("…"), "Truncated descriptions must end with an ellipsis"
+    assert_empty item_description(rss.items.first),
+                 "An overlong sentence must not be cut into a misleading fragment"
+  end
+
+  def test_item_description_keeps_complete_sentences_before_truncated_text
+    complete = 'Council approved the project.'
+    item = Struct.new(:description).new("#{complete} #{'word ' * 100}")
+    assert_equal complete, item_description(item)
+
+    truncated = Struct.new(:description).new("#{complete} Submissions close on We…")
+    assert_equal complete, item_description(truncated)
   end
 
   def test_item_description_reads_atom_summary
@@ -355,6 +368,12 @@ class RenderTest < Minitest::Test
                     "Raw feed URLs must not be sent to the summarizer"
   end
 
+  def test_extract_feed_content_omits_promotional_title_without_description
+    item = Struct.new(:title, :description).new('Philly Cheese Please! Support local booths', nil)
+    feed = Struct.new(:items).new([item])
+    assert_empty extract_feed_content(feed)
+  end
+
   def test_extract_feed_content_sorts_by_date_and_caps_items
     rss = RSS::Parser.parse(<<~XML, false)
       <?xml version="1.0"?>
@@ -384,7 +403,10 @@ class RenderTest < Minitest::Test
   end
 
   def test_labeled_summary_content_marks_items_as_independent
-    assert_equal '[ITEM 1] First. [ITEM 2] Second', labeled_summary_content(%w[First Second], 100)
+    assert_equal '[ITEM 1] TITLE: First. [ITEM 2] TITLE: Second',
+                 labeled_summary_content(%w[First Second], 100)
+    assert_equal '[ITEM 1] TITLE: Headline | DESCRIPTION: Concrete detail.',
+                 labeled_summary_content(['Headline - Concrete detail.'], 100)
   end
 
   def test_deduplicate_summary_lines_uses_normalized_title


### PR DESCRIPTION
## What changed
- retain only complete description sentences within the model input limit
- label titles and descriptions separately and exclude promotional title-only items
- remove generated sentences containing truncated ellipses
- strengthen prompt rules against completing source fragments

## Validation
- 71 tests, 244 assertions passing
- default and customized renders completed
- local HTTP preview served successfully