### PR TITLE
Reject low-signal generated facts

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -106,6 +106,8 @@ GROUNDED_FACTS_PROMPT = <<~PROMPT.strip.freeze
   Write at most one sentence of 35 words per usable item. Use the ITEM number exactly.
   Every sentence must describe only its matching ITEM. Never combine names, numbers, dates, places, or actions from different items.
   Prefer concrete facts from DESCRIPTION. Use TITLE only to clarify the same item.
+  Report the newest concrete action, decision, result, or operational status. For a live incident, include its latest stated size or status instead of merely naming its location.
+  Do not merely restate a headline or introductory phrase. Avoid vague constructions such as "highlights", "showcases", "lays out", or "a look at".
   Skip items that contain only a slogan, teaser, list of headlines, editorial note, or incomplete text.
   Preserve every name, place, date, number, numeric format, and operational status exactly as supplied.
   Do not add facts, context, transitions, labels, markdown, commentary, or keys other than "facts", "item", and "sentence".
@@ -567,7 +569,7 @@ def convert_markdown_links_to_html(text)
 end
 
 AI_SUMMARY_MODEL = 'lfm2.5-2.6b'
-SUMMARY_PIPELINE_VERSION = 'grounded-v1'
+SUMMARY_PIPELINE_VERSION = 'grounded-v2'
 
 def configured_ai_model
   ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
@@ -755,6 +757,8 @@ def valid_grounded_fact?(sentence, source)
   return false unless sentence.match?(/[.!?]\z/)
   return false unless split_summary_sentences(sentence).length == 1
   return false if sentence.split.length > 35
+  return false if sentence.match?(/\b(?:a look at|highlights|lays out|located on|questionable origin story|showcases)\b/i)
+  return false if sentence.match?(/\b(?:you|your)\b/i)
 
   (summary_number_tokens(sentence) - summary_number_tokens(source)).empty?
 end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -205,6 +205,24 @@ class RenderTest < Minitest::Test
     assert_equal ['Filing opened for 16 local contests.'], parse_grounded_facts(content, lines)
   end
 
+  def test_parse_grounded_facts_rejects_low_signal_restatements
+    lines = [
+      'Flat, Dutch Flat - Air Attack estimates the fire at 20 acres and holding within retardant lines.',
+      'Trail feature - Hiking the trail delivers a sense of awe in Yosemite.',
+      'Micro-grants - Nevada County awarded $20,000 to six organizations.'
+    ]
+    content = {
+      facts: [
+        { item: 1, sentence: 'Flat, Dutch Flat is located on Lowell Hill Road.' },
+        { item: 2, sentence: 'The trail story showcases a sense of awe in Yosemite.' },
+        { item: 3, sentence: 'Nevada County awarded $20,000 to six organizations.' }
+      ]
+    }.to_json
+
+    assert_equal ['Nevada County awarded $20,000 to six organizations.'],
+                 parse_grounded_facts(content, lines)
+  end
+
   def test_generate_grounded_facts_requests_json_object
     saved_endpoint = ENV['AI_API_ENDPOINT']
     ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'


### PR DESCRIPTION
Rejects headline restatements, vague feature language, second-person advice, and jokey teaser output from grounded summaries. Strengthens incident prompts to prefer the latest concrete status and bumps the summary pipeline cache version. All 78 tests and 259 assertions pass.