### PR TITLE
Stabilize per-item local inference

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -136,7 +136,7 @@ jobs:
           --host 127.0.0.1 \
           --port 8080 \
           --ctx-size 4096 \
-          --parallel 2 \
+          --parallel 1 \
           --threads 4 \
           --reasoning off \
           --reasoning-budget 0 \
@@ -155,6 +155,15 @@ jobs:
         fi
 
         bundle exec ruby render.rb
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+          echo "llama-server stopped during rendering" >&2
+          cat "$RUNNER_TEMP/llama-server.log"
+          exit 1
+        fi
+        if grep -q "Summary generation failed" public/index.html; then
+          echo "Refusing to deploy summary error placeholders" >&2
+          exit 1
+        fi
       env:
         AI_API_ENDPOINT: http://127.0.0.1:8080/v1/chat/completions
         AI_MODEL: ${{ github.event.inputs.ai_model || 'lfm2.5-2.6b' }}

--- a/render.rb
+++ b/render.rb
@@ -569,7 +569,7 @@ def convert_markdown_links_to_html(text)
 end
 
 AI_SUMMARY_MODEL = 'lfm2.5-2.6b'
-SUMMARY_PIPELINE_VERSION = 'grounded-v4'
+SUMMARY_PIPELINE_VERSION = 'grounded-v5'
 
 def configured_ai_model
   ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
@@ -810,6 +810,8 @@ def generate_grounded_facts(lines, context:)
     )
     if result[:error]
       errors << result[:error]
+      next fallback_grounded_fact(line) unless ENV['AI_API_ENDPOINT'].to_s.strip.empty?
+
       next
     end
 

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -325,6 +325,24 @@ class RenderTest < Minitest::Test
       def success?
         true
       end
+
+      def test_generate_grounded_facts_uses_source_fallback_after_local_server_error
+        saved_endpoint = ENV['AI_API_ENDPOINT']
+        ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'
+        original_post = HTTParty.method(:post)
+        HTTParty.define_singleton_method(:post) do |_url, _options|
+          raise HTTParty::Error, 'local server stopped'
+        end
+
+        line = 'Fire update - Crews held the fire at 20 acres.'
+        result = generate_grounded_facts([line], context: 'test')
+
+        assert_equal ['Crews held the fire at 20 acres.'], result[:facts]
+        assert_nil result[:error]
+      ensure
+        HTTParty.singleton_class.send(:define_method, :post, original_post) if original_post
+        saved_endpoint ? ENV['AI_API_ENDPOINT'] = saved_endpoint : ENV.delete('AI_API_ENDPOINT')
+      end
     end.new({ choices: [{ message: { content: '{"facts":[]}' } }] }.to_json, 200)
     HTTParty.define_singleton_method(:post) { |_url, _options| response }
 


### PR DESCRIPTION
Runs llama-server with one inference slot to avoid the observed concurrent-request crash, falls back to complete source sentences after configured-server errors, and refuses to deploy if llama-server dies or summary error placeholders reach the HTML. All 81 tests and 275 assertions pass.