### PR TITLE
Filter low-value grounded sentences

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -569,7 +569,7 @@ def convert_markdown_links_to_html(text)
 end
 
 AI_SUMMARY_MODEL = 'lfm2.5-2.6b'
-SUMMARY_PIPELINE_VERSION = 'grounded-v5'
+SUMMARY_PIPELINE_VERSION = 'grounded-v6'
 
 def configured_ai_model
   ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
@@ -586,6 +586,7 @@ def split_summary_sentences(text)
   chars.each_index do |index|
     next unless ['.', '!', '?'].include?(chars[index])
     next unless index == chars.length - 1 || chars[index + 1].strip.empty?
+    next if chars[index] == '.' && summary_abbreviation_period?(chars, index)
 
     sentence = chars[start_index..index].join.strip
     sentences << sentence unless sentence.empty?
@@ -595,6 +596,15 @@ def split_summary_sentences(text)
   tail = chars[start_index..]&.join.to_s.strip
   sentences << tail unless tail.empty?
   sentences
+end
+
+def summary_abbreviation_period?(chars, index)
+  prefix = chars[0...index].join
+  token = prefix.split.last.to_s.downcase
+  abbreviations = %w[
+    a.m apr aug calif dec dr feb jan jul jun mar mr mrs ms nev no nov oct p.m sep sept st u.s
+  ]
+  abbreviations.include?(token) || (token.length == 1 && token.match?(/[a-z]/))
 end
 
 def truncate_summary_sentences(text, max_words)
@@ -756,11 +766,35 @@ def valid_grounded_fact?(sentence, source)
   return false if sentence.empty? || sentence.include?('…') || sentence.include?('...')
   return false unless sentence.match?(/[.!?]\z/)
   return false unless split_summary_sentences(sentence).length == 1
-  return false if sentence.split.length > 35
+  return false if sentence.split.length > 35 || sentence.split.length < 4
+  return false if sentence.start_with?('?')
   return false if sentence.match?(/\b(?:a look at|highlights|lays out|located on|questionable origin story|showcases)\b/i)
   return false if sentence.match?(/\b(?:you|your)\b/i)
+  return false if low_signal_grounded_fact?(sentence)
 
   (summary_number_tokens(sentence) - summary_number_tokens(source)).empty?
+end
+
+def low_signal_grounded_fact?(sentence)
+  normalized = sentence.downcase
+  starts = [
+    'advance registration is required',
+    'however, when it comes',
+    'that’s exactly how it should be',
+    "that's exactly how it should be",
+    'view the agenda',
+    "we're tracking how",
+    'we’re tracking how'
+  ]
+  phrases = [
+    'all the info on what lies ahead',
+    'highly questionable origin',
+    'won’t think twice',
+    "won't think twice"
+  ]
+  starts.any? { |prefix| normalized.start_with?(prefix) } ||
+    phrases.any? { |phrase| normalized.include?(phrase) } ||
+    normalized.match?(/\A\d+\s+to\b/)
 end
 
 def parse_grounded_facts(content, lines)

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -223,6 +223,23 @@ class RenderTest < Minitest::Test
                  parse_grounded_facts(content, lines)
   end
 
+  def test_parse_grounded_facts_rejects_fragments_and_source_boilerplate
+    lines = [
+      'Election filing - Filing is extended until Aug. 12 for local contests.',
+      'Event - Advance registration is required.',
+      'Market report - We are tracking current prices.'
+    ]
+    content = {
+      facts: [
+        { item: 1, sentence: '12 to file candidacy documents.' },
+        { item: 2, sentence: 'Advance registration is required.' },
+        { item: 3, sentence: "We're tracking how that's going." }
+      ]
+    }.to_json
+
+    assert_empty parse_grounded_facts(content, lines)
+  end
+
   def test_generate_grounded_facts_requests_json_object
     saved_endpoint = ENV['AI_API_ENDPOINT']
     ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'
@@ -290,7 +307,7 @@ class RenderTest < Minitest::Test
       end
     end
     responses = [
-      response_class.new({ choices: [{ message: { content: '{"facts":[{"item":1,"sentence":"Water service continues."}]}' } }] }.to_json, 200),
+      response_class.new({ choices: [{ message: { content: '{"facts":[{"item":1,"sentence":"Water service continues for residents."}]}' } }] }.to_json, 200),
       response_class.new({ choices: [{ message: { content: '{"facts":[{"item":1,"sentence":"Candidate filing closes November 3."}]}' } }] }.to_json, 200)
     ]
 
@@ -299,12 +316,12 @@ class RenderTest < Minitest::Test
       responses.shift
     end
     lines = [
-      'Water stewardship - Water service continues.',
+      'Water stewardship - Water service continues for residents.',
       'Election filing - Candidate filing closes November 3.'
     ]
     result = generate_grounded_facts(lines, context: 'test')
 
-    assert_equal ['Water service continues.', 'Candidate filing closes November 3.'], result[:facts]
+    assert_equal ['Water service continues for residents.', 'Candidate filing closes November 3.'], result[:facts]
     assert_equal 2, requests.length
     first_content = JSON.parse(requests.first[1][:body]).dig('messages', 1, 'content')
     last_content = JSON.parse(requests.last[1][:body]).dig('messages', 1, 'content')
@@ -582,6 +599,8 @@ class RenderTest < Minitest::Test
   def test_split_summary_sentences_handles_punctuation_and_tail
     assert_equal ['First sentence.', 'Second!', 'Tail without punctuation'],
                  split_summary_sentences("First sentence. Second! Tail without punctuation")
+    assert_equal ['Filing closes Aug. 12 for local contests.', 'Another update.'],
+                 split_summary_sentences('Filing closes Aug. 12 for local contests. Another update.')
   end
 
   def test_labeled_summary_content_marks_items_as_independent


### PR DESCRIPTION
Handles common abbreviations without splitting dates or datelines, rejects source boilerplate and malformed fragments, and bumps the grounded cache version. All 82 tests and 278 assertions pass.