### PR TITLE
Filter remaining summary boilerplate

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -569,7 +569,7 @@ def convert_markdown_links_to_html(text)
 end
 
 AI_SUMMARY_MODEL = 'lfm2.5-2.6b'
-SUMMARY_PIPELINE_VERSION = 'grounded-v6'
+SUMMARY_PIPELINE_VERSION = 'grounded-v7'
 
 def configured_ai_model
   ENV.fetch('AI_MODEL', AI_SUMMARY_MODEL)
@@ -778,17 +778,25 @@ end
 def low_signal_grounded_fact?(sentence)
   normalized = sentence.downcase
   starts = [
+    'all candidates and information are subject to',
     'advance registration is required',
     'however, when it comes',
+    'releasing two tankers',
     'that’s exactly how it should be',
+    'that’s kind of a big deal',
     "that's exactly how it should be",
+    "that's kind of a big deal",
+    'tomorrow morning, thousands of people',
     'view the agenda',
     "we're tracking how",
     'we’re tracking how'
   ]
   phrases = [
     'all the info on what lies ahead',
+    'are excited to stage',
     'highly questionable origin',
+    'reveal new dimensions',
+    'surprising artistic background',
     'won’t think twice',
     "won't think twice"
   ]

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -240,6 +240,23 @@ class RenderTest < Minitest::Test
     assert_empty parse_grounded_facts(content, lines)
   end
 
+  def test_parse_grounded_facts_rejects_promotional_and_contextless_lines
+    lines = [
+      'Fire update - Releasing two tankers back to base.',
+      'Water feature - Tomorrow morning, thousands of people will turn on a faucet.',
+      'Astrology - That’s kind of a big deal.'
+    ]
+    content = {
+      facts: [
+        { item: 1, sentence: 'Releasing two tankers back to base.' },
+        { item: 2, sentence: 'Tomorrow morning, thousands of people will turn on a faucet.' },
+        { item: 3, sentence: 'That’s kind of a big deal.' }
+      ]
+    }.to_json
+
+    assert_empty parse_grounded_facts(content, lines)
+  end
+
   def test_generate_grounded_facts_requests_json_object
     saved_endpoint = ENV['AI_API_ENDPOINT']
     ENV['AI_API_ENDPOINT'] = 'http://127.0.0.1:8080/v1/chat/completions'


### PR DESCRIPTION
Rejects observed contextless incident lines, promotional ledes, candidate caveats, source asides, and vague feature language before deterministic assembly. All 83 tests and 280 assertions pass.